### PR TITLE
Update Firefox version information in readme (no longer beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Wasm_of_ocaml relies on the Binaryen toolchain ([version 116](https://github.com
 
 ## Supported engines
 
-The generated code works with Chrome 11.9, [node V8 canary](https://nodejs.org/download/v8-canary/v21.0.0-v8-canary20230927fa59f85d60/) and [Firefox 121](https://www.mozilla.org/en-US/firefox/channel/desktop/).
+The generated code works with Chrome 11.9, [node V8 canary](https://nodejs.org/download/v8-canary/v21.0.0-v8-canary20230927fa59f85d60/) and [Firefox 121](https://www.mozilla.org/en-US/firefox/new/).
 
 In particular, the output code requires the following [Wasm extensions](https://webassembly.org/roadmap/) to run:
 - [the GC extension](https://github.com/WebAssembly/gc), including functional references and 31-bit integers

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Wasm_of_ocaml relies on the Binaryen toolchain ([version 116](https://github.com
 
 ## Supported engines
 
-The generated code works with Chrome 11.9, [node V8 canary](https://nodejs.org/download/v8-canary/v21.0.0-v8-canary20230927fa59f85d60/) and Firefox 121 (currently, [Firefox Beta](https://www.mozilla.org/en-US/firefox/channel/desktop/)).
+The generated code works with Chrome 11.9, [node V8 canary](https://nodejs.org/download/v8-canary/v21.0.0-v8-canary20230927fa59f85d60/) and [Firefox 121](https://www.mozilla.org/en-US/firefox/channel/desktop/).
 
 In particular, the output code requires the following [Wasm extensions](https://webassembly.org/roadmap/) to run:
 - [the GC extension](https://github.com/WebAssembly/gc), including functional references and 31-bit integers


### PR DESCRIPTION
I believe that Firefox 121 is no longer in beta.