### PR TITLE
Tune optimization profiles

### DIFF
--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -140,9 +140,10 @@ let dead_code_elimination in_file out_file =
   filter_unused_primitives primitives usage_file
 
 let optimization_options =
-  [| [ "-O2"; "--skip-pass=inlining-optimizing" ]
-   ; [ "-O2"; "--skip-pass=inlining-optimizing"; "--traps-never-happen" ]
-   ; [ "-O3"; "--traps-never-happen" ]
+  [| [ "--simplify-locals-notee-nostructure"; "--vacuum"; "--reorder-locals"]
+       (* --opt=1 *)
+   ; [ "-O2"; "--traps-never-happen" ] (* --opt=2 *)
+   ; [ "-O3"; "--traps-never-happen" ] (* --opt=3 *)
   |]
 
 let optimize ~profile in_file out_file =


### PR DESCRIPTION
Tunes the Binaryen optimization passes to achieve two goals:

- A fast build with `--opt=1`
- A fast executable with `--opt={2,3}`, without making the build times unreasonably long.

It turns out that only a handful of selected passes for `--opt=1` and `-O2` and `-O3` seem to achieve these goals for the time being.