### PR TITLE
Sourcemap support for wasm

### DIFF
--- a/compiler/bin-wasm_of_ocaml/cmd_arg.mli
+++ b/compiler/bin-wasm_of_ocaml/cmd_arg.mli
@@ -26,6 +26,7 @@ type t =
   ; runtime_files : string list
   ; output_file : string * bool
   ; input_file : string
+  ; enable_source_maps : bool
   ; params : (string * string) list
   }
 

--- a/compiler/bin-wasm_of_ocaml/dune
+++ b/compiler/bin-wasm_of_ocaml/dune
@@ -43,5 +43,4 @@
 (install
  (section man)
  (package wasm_of_ocaml-compiler)
- (files
-  wasm_of_ocaml.1))
+ (files wasm_of_ocaml.1))

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -576,7 +576,9 @@ let configure formatter =
 
 type 'a target =
   | JavaScript : Pretty_print.t -> Source_map.t option target
-  | Wasm : (Deadcode.variable_uses * Effects.in_cps * Code.program) target
+  | Wasm
+      : (Deadcode.variable_uses * Effects.in_cps * Code.program * Parse_bytecode.Debug.t)
+        target
 
 let target_flag (type a) (t : a target) =
   match t with
@@ -631,7 +633,7 @@ let full
       source_map
   | Wasm ->
       let (p, live_vars), _, in_cps = r in
-      live_vars, in_cps, p
+      live_vars, in_cps, p, d
 
 let full_no_source_map ~formatter ~standalone ~wrap_with_fun ~profile ~linkall d p =
   let (_ : Source_map.t option) =

--- a/compiler/lib/driver.mli
+++ b/compiler/lib/driver.mli
@@ -22,7 +22,9 @@ type profile
 
 type 'a target =
   | JavaScript : Pretty_print.t -> Source_map.t option target
-  | Wasm : (Deadcode.variable_uses * Effects.in_cps * Code.program) target
+  | Wasm
+      : (Deadcode.variable_uses * Effects.in_cps * Code.program * Parse_bytecode.Debug.t)
+        target
 
 val f :
      target:'result target

--- a/compiler/lib/generate.mli
+++ b/compiler/lib/generate.mli
@@ -29,3 +29,9 @@ val f :
   -> Javascript.program
 
 val init : unit -> unit
+
+val source_location :
+     Parse_bytecode.Debug.t
+  -> ?force:Parse_bytecode.Debug.force
+  -> Code.loc
+  -> Javascript.location

--- a/compiler/lib/link_js.ml
+++ b/compiler/lib/link_js.ml
@@ -469,7 +469,7 @@ let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~source
               let s = sourceMappingURL_base64 ^ Base64.encode_exn data in
               Line_writer.write oc s
           | Some file ->
-              Source_map_io.to_file sm file;
+              Source_map_io.to_file sm ~file;
               let s = sourceMappingURL ^ Filename.basename file in
               Line_writer.write oc s));
       if times () then Format.eprintf "  sourcemap: %a@." Timer.print t

--- a/compiler/lib/source_map_io.mli
+++ b/compiler/lib/source_map_io.mli
@@ -23,6 +23,13 @@ val enabled : bool
 
 val to_string : t -> string
 
-val to_file : t -> string -> unit
-
 val of_string : string -> t
+
+val of_file_no_mappings : string -> t * string option
+(** Read source map from a file without parsing the mappings (which can be costly). The
+    [mappings] field is returned empty and the raw string is returned alongside the map.
+ *)
+
+val to_file : ?mappings:string -> t -> file:string -> unit
+(** Write to a file. If a string is supplied as [mappings], use it instead of the
+    sourcemap's [mappings]. *)

--- a/compiler/lib/wasm/wa_asm_output.ml
+++ b/compiler/lib/wasm/wa_asm_output.ml
@@ -402,6 +402,9 @@ module Output () = struct
     | Return_call (x, l) ->
         Feature.require tail_call;
         concat_map expression l ^^ line (string "return_call " ^^ index x)
+    | Location (_, i) ->
+        (* Source maps not supported for the non-GC target *)
+        instruction i
     | ArraySet _ | StructSet _ | Return_call_ref _ -> assert false (* Not supported *)
 
   let escape_string s =

--- a/compiler/lib/wasm/wa_ast.ml
+++ b/compiler/lib/wasm/wa_ast.ml
@@ -187,6 +187,8 @@ and instruction =
   | Return_call_indirect of func_type * expression * expression list
   | Return_call of var * expression list
   | Return_call_ref of var * expression * expression list
+  | Location of Code.loc * instruction
+      (** Instruction with attached location information *)
 
 type import_desc =
   | Fun of func_type

--- a/compiler/lib/wasm/wa_code_generation.ml
+++ b/compiler/lib/wasm/wa_code_generation.ml
@@ -267,6 +267,17 @@ let blk l st =
   let (), st = l { st with instrs = [] } in
   List.rev st.instrs, { st with instrs }
 
+let with_location loc instrs st =
+  let current_instrs = st.instrs in
+  let (), st = instrs { st with instrs = [] } in
+  let[@tail_mod_cons] rec add_loc loc = function
+    | [] -> current_instrs
+    | W.Nop :: rem -> W.Nop :: add_loc loc rem
+    | Location _ :: _ as l -> l @ current_instrs (* Stop on the first location *)
+    | i :: rem -> W.Location (loc, i) :: add_loc loc rem
+  in
+  (), { st with instrs = add_loc loc st.instrs }
+
 let cast ?(nullable = false) typ e =
   let* e = e in
   match typ, e with

--- a/compiler/lib/wasm/wa_code_generation.mli
+++ b/compiler/lib/wasm/wa_code_generation.mli
@@ -119,6 +119,8 @@ val is_small_constant : Wa_ast.expression -> bool t
 
 val get_i31_value : int -> int option t
 
+val with_location : Code.loc -> unit t -> unit t
+
 type type_def =
   { supertype : Wa_ast.var option
   ; final : bool

--- a/compiler/lib/wasm/wa_generate.ml
+++ b/compiler/lib/wasm/wa_generate.ml
@@ -604,23 +604,30 @@ module Generate (Target : Wa_target_sig.S) = struct
             | (Not | Lt | Le | Eq | Neq | Ult | Array_get | IsInt | Vectlength), _ ->
                 assert false))
 
-  and translate_instr ctx stack_ctx context (i, _) =
-    match i with
-    | Assign (x, y) ->
-        let* () = assign x (load y) in
-        Stack.assign stack_ctx x
-    | Let (x, e) ->
-        if ctx.live.(Var.idx x) = 0
-        then drop (translate_expr ctx stack_ctx context x e)
-        else store x (translate_expr ctx stack_ctx context x e)
-    | Set_field (x, n, y) -> Memory.set_field (load x) n (load y)
-    | Offset_ref (x, n) ->
-        Memory.set_field
-          (load x)
-          0
-          (Value.val_int
-             Arith.(Value.int_val (Memory.field (load x) 0) + const (Int32.of_int n)))
-    | Array_set (x, y, z) -> Memory.array_set (load x) (load y) (load z)
+  and emit_location loc instrs =
+    match loc with
+    | No -> instrs
+    | Before _ | After _ -> with_location loc instrs
+
+  and translate_instr ctx stack_ctx context (i, loc) =
+    emit_location
+      loc
+      (match i with
+      | Assign (x, y) ->
+          let* () = assign x (load y) in
+          Stack.assign stack_ctx x
+      | Let (x, e) ->
+          if ctx.live.(Var.idx x) = 0
+          then drop (translate_expr ctx stack_ctx context x e)
+          else store x (translate_expr ctx stack_ctx context x e)
+      | Set_field (x, n, y) -> Memory.set_field (load x) n (load y)
+      | Offset_ref (x, n) ->
+          Memory.set_field
+            (load x)
+            0
+            (Value.val_int
+               Arith.(Value.int_val (Memory.field (load x) 0) + const (Int32.of_int n)))
+      | Array_set (x, y, z) -> Memory.array_set (load x) (load y) (load z))
 
   and translate_instrs ctx stack_ctx context l =
     match l with
@@ -823,92 +830,96 @@ module Generate (Target : Wa_target_sig.S) = struct
             else code ~context
           in
           translate_tree result_typ fall_through pc' context
-      | [] -> (
+      | [] ->
           let block = Addr.Map.find pc ctx.blocks in
           let* global_context = get_context in
           let stack_ctx = Stack.start_block ~context:global_context stack_info pc in
           let* () = translate_instrs ctx stack_ctx context block.body in
           let* () = Stack.perform_reloads stack_ctx (`Branch (fst block.branch)) in
           let* () = Stack.perform_spilling stack_ctx (`Block pc) in
-          match fst block.branch with
-          | Branch cont ->
-              translate_branch result_typ fall_through pc cont context stack_ctx
-          | Return x -> (
-              let* e = load x in
-              match fall_through with
-              | `Return -> instr (Push e)
-              | `Block _ -> instr (Return (Some e)))
-          | Cond (x, cont1, cont2) ->
-              let context' = extend_context fall_through context in
-              if_
-                { params = []; result = result_typ }
-                (Value.check_is_not_zero (load x))
-                (translate_branch result_typ fall_through pc cont1 context' stack_ctx)
-                (translate_branch result_typ fall_through pc cont2 context' stack_ctx)
-          | Stop -> (
-              let* e = Value.unit in
-              match fall_through with
-              | `Return -> instr (Push e)
-              | `Block _ -> instr (Return (Some e)))
-          | Switch (x, a1, a2) ->
-              let l =
-                List.filter
-                  ~f:(fun pc' -> Stack.stack_adjustment_needed stack_ctx ~src:pc ~dst:pc')
-                  (List.rev (Addr.Set.elements (Wa_structure.get_edges dom pc)))
-              in
-              let br_table e a context =
-                let len = Array.length a in
-                let l = Array.to_list (Array.sub a ~pos:0 ~len:(len - 1)) in
-                let dest (pc, args) =
-                  assert (List.is_empty args);
-                  label_index context pc
+          let branch, loc = block.branch in
+          emit_location
+            loc
+            (match branch with
+            | Branch cont ->
+                translate_branch result_typ fall_through pc cont context stack_ctx
+            | Return x -> (
+                let* e = load x in
+                match fall_through with
+                | `Return -> instr (Push e)
+                | `Block _ -> instr (Return (Some e)))
+            | Cond (x, cont1, cont2) ->
+                let context' = extend_context fall_through context in
+                if_
+                  { params = []; result = result_typ }
+                  (Value.check_is_not_zero (load x))
+                  (translate_branch result_typ fall_through pc cont1 context' stack_ctx)
+                  (translate_branch result_typ fall_through pc cont2 context' stack_ctx)
+            | Stop -> (
+                let* e = Value.unit in
+                match fall_through with
+                | `Return -> instr (Push e)
+                | `Block _ -> instr (Return (Some e)))
+            | Switch (x, a1, a2) ->
+                let l =
+                  List.filter
+                    ~f:(fun pc' ->
+                      Stack.stack_adjustment_needed stack_ctx ~src:pc ~dst:pc')
+                    (List.rev (Addr.Set.elements (Wa_structure.get_edges dom pc)))
                 in
-                let* e = e in
-                instr (Br_table (e, List.map ~f:dest l, dest a.(len - 1)))
-              in
-              let rec nest l context =
-                match l with
-                | pc' :: rem ->
-                    let* () =
-                      Wa_code_generation.block
-                        { params = []; result = [] }
-                        (nest rem (`Block pc' :: context))
-                    in
-                    let* () = Stack.adjust_stack stack_ctx ~src:pc ~dst:pc' in
-                    instr (Br (label_index context pc', None))
-                | [] -> (
-                    match a1, a2 with
-                    | [||], _ -> br_table (Memory.tag (load x)) a2 context
-                    | _, [||] -> br_table (Value.int_val (load x)) a1 context
-                    | _ ->
-                        (*ZZZ Use Br_on_cast *)
-                        let context' = extend_context fall_through context in
-                        if_
-                          { params = []; result = result_typ }
-                          (Value.check_is_int (load x))
-                          (br_table (Value.int_val (load x)) a1 context')
-                          (br_table (Memory.tag (load x)) a2 context'))
-              in
-              nest l context
-          | Raise (x, _) ->
-              let* e = load x in
-              let* tag = register_import ~name:exception_name (Tag Value.value) in
-              instr (Throw (tag, e))
-          | Pushtrap (cont, x, cont', _) ->
-              handle_exceptions
-                ~result_typ
-                ~fall_through
-                ~context:(extend_context fall_through context)
-                (wrap_with_handlers
-                   p
-                   (fst cont)
-                   (fun ~result_typ ~fall_through ~context ->
-                     translate_branch result_typ fall_through pc cont context stack_ctx))
-                x
-                (fun ~result_typ ~fall_through ~context ->
-                  translate_branch result_typ fall_through pc cont' context stack_ctx)
-          | Poptrap cont ->
-              translate_branch result_typ fall_through pc cont context stack_ctx)
+                let br_table e a context =
+                  let len = Array.length a in
+                  let l = Array.to_list (Array.sub a ~pos:0 ~len:(len - 1)) in
+                  let dest (pc, args) =
+                    assert (List.is_empty args);
+                    label_index context pc
+                  in
+                  let* e = e in
+                  instr (Br_table (e, List.map ~f:dest l, dest a.(len - 1)))
+                in
+                let rec nest l context =
+                  match l with
+                  | pc' :: rem ->
+                      let* () =
+                        Wa_code_generation.block
+                          { params = []; result = [] }
+                          (nest rem (`Block pc' :: context))
+                      in
+                      let* () = Stack.adjust_stack stack_ctx ~src:pc ~dst:pc' in
+                      instr (Br (label_index context pc', None))
+                  | [] -> (
+                      match a1, a2 with
+                      | [||], _ -> br_table (Memory.tag (load x)) a2 context
+                      | _, [||] -> br_table (Value.int_val (load x)) a1 context
+                      | _ ->
+                          (*ZZZ Use Br_on_cast *)
+                          let context' = extend_context fall_through context in
+                          if_
+                            { params = []; result = result_typ }
+                            (Value.check_is_int (load x))
+                            (br_table (Value.int_val (load x)) a1 context')
+                            (br_table (Memory.tag (load x)) a2 context'))
+                in
+                nest l context
+            | Raise (x, _) ->
+                let* e = load x in
+                let* tag = register_import ~name:exception_name (Tag Value.value) in
+                instr (Throw (tag, e))
+            | Pushtrap (cont, x, cont', _) ->
+                handle_exceptions
+                  ~result_typ
+                  ~fall_through
+                  ~context:(extend_context fall_through context)
+                  (wrap_with_handlers
+                     p
+                     (fst cont)
+                     (fun ~result_typ ~fall_through ~context ->
+                       translate_branch result_typ fall_through pc cont context stack_ctx))
+                  x
+                  (fun ~result_typ ~fall_through ~context ->
+                    translate_branch result_typ fall_through pc cont' context stack_ctx)
+            | Poptrap cont ->
+                translate_branch result_typ fall_through pc cont context stack_ctx)
     and translate_branch result_typ fall_through src (dst, args) context stack_ctx =
       let* () =
         if List.is_empty args
@@ -1110,7 +1121,7 @@ let fix_switch_branches p =
     p.blocks;
   !p'
 
-let f ch (p : Code.program) ~live_vars ~in_cps =
+let f ch (p : Code.program) ~live_vars ~in_cps ~debug =
   let p = if Config.Flag.effects () then fix_switch_branches p else p in
   match target with
   | `Core ->
@@ -1121,5 +1132,5 @@ let f ch (p : Code.program) ~live_vars ~in_cps =
   | `GC ->
       let module G = Generate (Wa_gc_target) in
       let fields, js_code = G.f ~live_vars ~in_cps p in
-      Wa_wat_output.f ch fields;
+      Wa_wat_output.f ~debug ch fields;
       js_code

--- a/compiler/lib/wasm/wa_generate.mli
+++ b/compiler/lib/wasm/wa_generate.mli
@@ -5,4 +5,5 @@ val f :
   -> Code.program
   -> live_vars:int array
   -> in_cps:Effects.in_cps
+  -> debug:Parse_bytecode.Debug.t
   -> string list * (string * Javascript.expression) list

--- a/compiler/lib/wasm/wa_initialize_locals.ml
+++ b/compiler/lib/wasm/wa_initialize_locals.ml
@@ -92,6 +92,7 @@ and scan_instruction ctx i =
   | Return_call_indirect (_, e', l) | Return_call_ref (_, e', l) ->
       scan_expressions ctx l;
       scan_expression ctx e'
+  | Location (_, i) -> scan_instruction ctx i
 
 and scan_instructions ctx l =
   let ctx = fork_context ctx in

--- a/compiler/lib/wasm/wa_wat_output.mli
+++ b/compiler/lib/wasm/wa_wat_output.mli
@@ -1,1 +1,1 @@
-val f : out_channel -> Wa_ast.module_field list -> unit
+val f : debug:Parse_bytecode.Debug.t -> out_channel -> Wa_ast.module_field list -> unit

--- a/compiler/tests-jsoo/lib-effects/dune
+++ b/compiler/tests-jsoo/lib-effects/dune
@@ -3,7 +3,9 @@
  (enabled_if
   (and
    (>= %{ocaml_version} 5)
-   (or (= %{profile} using-effects) (= %{profile} wasm-effects))))
+   (or
+    (= %{profile} using-effects)
+    (= %{profile} wasm-effects))))
  (inline_tests
   ;; This requires the unreleased dune 3.7 to work
   (enabled_if true)

--- a/compiler/tests-num/dune
+++ b/compiler/tests-num/dune
@@ -9,7 +9,10 @@
 
 (rule
  (target main.referencejs)
- (enabled_if (and (<> %{profile} wasm) (<> %{profile} wasm-effects)))
+ (enabled_if
+  (and
+   (<> %{profile} wasm)
+   (<> %{profile} wasm-effects)))
  (deps main.bc.js)
  (action
   (with-stdout-to
@@ -27,7 +30,10 @@
 (rule
  (alias runtest)
  ;; ZZZ Need to modify the num library
- (enabled_if (and (<> %{profile} wasm) (<> %{profile} wasm-effects)))
+ (enabled_if
+  (and
+   (<> %{profile} wasm)
+   (<> %{profile} wasm-effects)))
  (deps main.reference main.referencejs)
  (action
   (diff main.reference main.referencejs)))

--- a/compiler/tests-ocaml/lib-hashtbl/dune
+++ b/compiler/tests-ocaml/lib-hashtbl/dune
@@ -22,14 +22,20 @@
 
 (rule
  (alias runtest)
- (enabled_if (and (<> %{profile} wasm) (<> %{profile} wasm-effects)))
+ (enabled_if
+  (and
+   (<> %{profile} wasm)
+   (<> %{profile} wasm-effects)))
  (deps hfun.referencejs hfun.reference)
  (action
   (diff hfun.referencejs hfun.reference)))
 
 (rule
  (alias runtest)
- (enabled_if (or (= %{profile} wasm) (= %{profile} wasm-effects)))
+ (enabled_if
+  (or
+   (= %{profile} wasm)
+   (= %{profile} wasm-effects)))
  (deps hfun.referencejs hfun.reference-wasm)
  (action
   (diff hfun.referencejs hfun.reference-wasm)))

--- a/compiler/tests-sourcemap/dune
+++ b/compiler/tests-sourcemap/dune
@@ -21,7 +21,10 @@
 (rule
  (target dump)
  (enabled_if
-  (and (<> %{profile} using-effects) (<> %{profile} wasm) (<> %{profile} wasm-effects)))
+  (and
+   (<> %{profile} using-effects)
+   (<> %{profile} wasm)
+   (<> %{profile} wasm-effects)))
  (action
   (with-stdout-to
    %{target}
@@ -30,7 +33,10 @@
 (rule
  (alias runtest)
  (enabled_if
-  (and (<> %{profile} using-effects) (<> %{profile} wasm) (<> %{profile} wasm-effects)))
+  (and
+   (<> %{profile} using-effects)
+   (<> %{profile} wasm)
+   (<> %{profile} wasm-effects)))
  (deps dump.reference dump)
  (action
   (diff dump.reference dump)))


### PR DESCRIPTION
Implement mapping between source and wasm locations.

To work, this requires a version of Binaryen compiled with Jérôme's patch WebAssembly/binaryen#6372, so I’m opening this a draft for now.

Single-stepping can jump around in slightly surprising ways in the OCaml code, due to the different order of operations in wasm. This could be improved by modifying Binaryen to support “no location” annotations. Another future improvement can be to support mapping Wasm identifiers to OCaml ones.