### PR TITLE
Store long-lived toplevel values into globals

### DIFF
--- a/compiler/lib/freevars.ml
+++ b/compiler/lib/freevars.ml
@@ -100,8 +100,8 @@ type st =
   ; mutable revisited : bool
   }
 
-let find_loops p =
-  let in_loop = ref Addr.Map.empty in
+let find_loops p in_loop pc =
+  let in_loop = ref in_loop in
   let index = ref 0 in
   let state = ref Addr.Map.empty in
   let stack = Stack.create () in
@@ -141,8 +141,16 @@ let find_loops p =
       if st.revisited
       then List.iter !l ~f:(fun pc' -> in_loop := Addr.Map.add pc' pc !in_loop))
   in
-  Code.fold_closures p (fun _ _ (pc, _) () -> traverse pc) ();
+  traverse pc;
   !in_loop
+
+let find_loops_in_closure p pc = find_loops p Addr.Map.empty pc
+
+let find_all_loops p =
+  Code.fold_closures
+    p
+    (fun _ _ (pc, _) (in_loop : _ Addr.Map.t) -> find_loops p in_loop pc)
+    Addr.Map.empty
 
 let mark_variables in_loop p =
   let vars = Var.Tbl.make () (-1) in
@@ -210,7 +218,7 @@ let free_variables vars in_loop p =
 let f p =
   Code.invariant p;
   let t = Timer.make () in
-  let in_loop = find_loops p in
+  let in_loop = find_all_loops p in
   let vars = mark_variables in_loop p in
   let free_vars = free_variables vars in_loop p in
   if times () then Format.eprintf "  free vars: %a@." Timer.print t;

--- a/compiler/lib/freevars.mli
+++ b/compiler/lib/freevars.mli
@@ -27,4 +27,6 @@ val iter_instr_free_vars : (Code.Var.t -> unit) -> Code.instr -> unit
 
 val iter_last_free_var : (Code.Var.t -> unit) -> Code.last -> unit
 
+val find_loops_in_closure : Code.program -> Code.Addr.t -> Code.Addr.t Code.Addr.Map.t
+
 val f : Code.program -> Code.Var.Set.t Code.Addr.Map.t

--- a/compiler/lib/wasm/wa_code_generation.ml
+++ b/compiler/lib/wasm/wa_code_generation.ml
@@ -24,7 +24,8 @@ type context =
   ; mutable constant_globals : constant_global Var.Map.t
   ; mutable other_fields : W.module_field list
   ; mutable imports : (Var.t * Wa_ast.import_desc) StringMap.t StringMap.t
-  ; types : (string, Var.t) Hashtbl.t
+  ; type_names : (string, Var.t) Hashtbl.t
+  ; types : (Var.t, Wa_ast.type_field) Hashtbl.t
   ; mutable closure_envs : Var.t Var.Map.t
         (** GC: mapping of recursive functions to their shared environment *)
   ; mutable apply_funs : Var.t IntMap.t
@@ -46,6 +47,7 @@ let make_context () =
   ; constant_globals = Var.Map.empty
   ; other_fields = []
   ; imports = StringMap.empty
+  ; type_names = Hashtbl.create 128
   ; types = Hashtbl.create 128
   ; closure_envs = Var.Map.empty
   ; apply_funs = IntMap.empty
@@ -114,14 +116,42 @@ type type_def =
 let register_type nm gen_typ st =
   let context = st.context in
   let { supertype; final; typ }, st = gen_typ () st in
-  ( (try Hashtbl.find context.types nm
+  ( (try Hashtbl.find context.type_names nm
      with Not_found ->
        let name = Var.fresh_n nm in
-       context.other_fields <-
-         Type [ { name; typ; supertype; final } ] :: context.other_fields;
-       Hashtbl.add context.types nm name;
+       let type_field = { Wa_ast.name; typ; supertype; final } in
+       context.other_fields <- Type [ type_field ] :: context.other_fields;
+       Hashtbl.add context.type_names nm name;
+       Hashtbl.add context.types name type_field;
        name)
   , st )
+
+let rec type_index_sub ty ty' st =
+  if Var.equal ty ty'
+  then true, st
+  else
+    let type_field = Hashtbl.find st.context.types ty in
+    match type_field.supertype with
+    | None -> false, st
+    | Some ty -> type_index_sub ty ty' st
+
+let heap_type_sub (ty : W.heap_type) (ty' : W.heap_type) st =
+  match ty, ty' with
+  | Func, Func
+  | Extern, Extern
+  | (Any | Eq | I31 | Type _), Any
+  | (Eq | I31 | Type _), Eq
+  | I31, I31 -> true, st
+  | Type t, Type t' -> type_index_sub t t' st
+  (* Func and Extern are only in suptyping relation with themselves *)
+  | Func, _
+  | _, Func
+  | Extern, _
+  | _, Extern
+  (* Any has no supertype *)
+  | Any, _
+  (* I31, struct and arrays have no subtype (of a different kind) *)
+  | _, (I31 | Type _) -> false, st
 
 let register_global name ?(constant = false) typ init st =
   st.context.other_fields <- W.Global { name; typ; init } :: st.context.other_fields;

--- a/compiler/lib/wasm/wa_code_generation.mli
+++ b/compiler/lib/wasm/wa_code_generation.mli
@@ -8,7 +8,8 @@ type context =
   ; mutable constant_globals : constant_global Code.Var.Map.t
   ; mutable other_fields : Wa_ast.module_field list
   ; mutable imports : (Code.Var.t * Wa_ast.import_desc) StringMap.t StringMap.t
-  ; types : (string, Code.Var.t) Hashtbl.t
+  ; type_names : (string, Code.Var.t) Hashtbl.t
+  ; types : (Code.Var.t, Wa_ast.type_field) Hashtbl.t
   ; mutable closure_envs : Code.Var.t Code.Var.Map.t
         (** GC: mapping of recursive functions to their shared environment *)
   ; mutable apply_funs : Code.Var.t Stdlib.IntMap.t
@@ -123,6 +124,8 @@ type type_def =
   }
 
 val register_type : string -> (unit -> type_def t) -> Wa_ast.var t
+
+val heap_type_sub : Wa_ast.heap_type -> Wa_ast.heap_type -> bool t
 
 val register_import :
   ?import_module:string -> name:string -> Wa_ast.import_desc -> Wa_ast.var t

--- a/compiler/lib/wasm/wa_code_generation.mli
+++ b/compiler/lib/wasm/wa_code_generation.mli
@@ -23,9 +23,11 @@ type context =
   ; mutable strings : string list
   ; mutable string_index : int StringMap.t
   ; mutable fragments : Javascript.expression StringMap.t
+  ; mutable globalized_variables : Code.Var.Set.t
+  ; value_type : Wa_ast.value_type
   }
 
-val make_context : unit -> context
+val make_context : value_type:Wa_ast.value_type -> context
 
 type 'a t
 
@@ -163,7 +165,6 @@ val need_dummy_fun : cps:bool -> arity:int -> Code.Var.t t
 
 val function_body :
      context:context
-  -> value_type:Wa_ast.value_type
   -> param_count:int
   -> body:unit t
   -> Wa_ast.value_type list * Wa_ast.instruction list

--- a/compiler/lib/wasm/wa_curry.ml
+++ b/compiler/lib/wasm/wa_curry.ml
@@ -82,9 +82,7 @@ module Make (Target : Wa_target_sig.S) = struct
       in
       loop m [] f None
     in
-    let locals, body =
-      function_body ~context ~value_type:Value.value ~param_count:2 ~body
-    in
+    let locals, body = function_body ~context ~param_count:2 ~body in
     W.Function { name; exported_name = None; typ = func_type 1; locals; body }
 
   let curry_name n m = Printf.sprintf "curry_%d_%d" n m
@@ -142,9 +140,7 @@ module Make (Target : Wa_target_sig.S) = struct
       in
       Stack.perform_spilling stack_ctx (`Instr ret)
     in
-    let locals, body =
-      function_body ~context ~value_type:Value.value ~param_count:2 ~body
-    in
+    let locals, body = function_body ~context ~param_count:2 ~body in
     W.Function { name; exported_name = None; typ = func_type 1; locals; body }
     :: functions
 
@@ -185,9 +181,7 @@ module Make (Target : Wa_target_sig.S) = struct
       in
       loop m [] f None
     in
-    let locals, body =
-      function_body ~context ~value_type:Value.value ~param_count:3 ~body
-    in
+    let locals, body = function_body ~context ~param_count:3 ~body in
     W.Function { name; exported_name = None; typ = func_type 2; locals; body }
 
   let cps_curry_name n m = Printf.sprintf "cps_curry_%d_%d" n m
@@ -248,9 +242,7 @@ module Make (Target : Wa_target_sig.S) = struct
       let* c = call ~cps:false ~arity:1 (load cont) [ e ] in
       instr (W.Return (Some c))
     in
-    let locals, body =
-      function_body ~context ~value_type:Value.value ~param_count:3 ~body
-    in
+    let locals, body = function_body ~context ~param_count:3 ~body in
     W.Function { name; exported_name = None; typ = func_type 2; locals; body }
     :: functions
 
@@ -309,9 +301,7 @@ module Make (Target : Wa_target_sig.S) = struct
          in
          build_applies (load f) l)
     in
-    let locals, body =
-      function_body ~context ~value_type:Value.value ~param_count:(arity + 1) ~body
-    in
+    let locals, body = function_body ~context ~param_count:(arity + 1) ~body in
     W.Function { name; exported_name = None; typ = func_type arity; locals; body }
 
   let cps_apply ~context ~arity ~name =
@@ -372,9 +362,7 @@ module Make (Target : Wa_target_sig.S) = struct
          let* () = push (call ~cps:true ~arity:2 (load f) [ x; iterate ]) in
          Stack.perform_spilling stack_ctx (`Instr ret))
     in
-    let locals, body =
-      function_body ~context ~value_type:Value.value ~param_count:(arity + 1) ~body
-    in
+    let locals, body = function_body ~context ~param_count:(arity + 1) ~body in
     W.Function { name; exported_name = None; typ = func_type arity; locals; body }
 
   let dummy ~context ~cps ~arity ~name =
@@ -399,9 +387,7 @@ module Make (Target : Wa_target_sig.S) = struct
       in
       instr (W.Return (Some e))
     in
-    let locals, body =
-      function_body ~context ~value_type:Value.value ~param_count:(arity + 1) ~body
-    in
+    let locals, body = function_body ~context ~param_count:(arity + 1) ~body in
     W.Function { name; exported_name = None; typ = func_type arity; locals; body }
 
   let f ~context =

--- a/compiler/lib/wasm/wa_generate.ml
+++ b/compiler/lib/wasm/wa_generate.ml
@@ -954,10 +954,12 @@ module Generate (Target : Wa_target_sig.S) = struct
       | None -> 0
       | Some _ -> List.length params + 1
     in
+    (match name_opt with
+    | None -> ctx.global_context.globalized_variables <- Wa_globalize.f p g ctx.closures
+    | Some _ -> ());
     let locals, body =
       function_body
         ~context:ctx.global_context
-        ~value_type:Value.value
         ~param_count
         ~body:
           (let* () = build_initial_env in
@@ -990,7 +992,6 @@ module Generate (Target : Wa_target_sig.S) = struct
     let locals, body =
       function_body
         ~context:ctx.global_context
-        ~value_type:Value.value
         ~param_count:(List.length typ.W.params)
         ~body
     in
@@ -1020,7 +1021,7 @@ module Generate (Target : Wa_target_sig.S) = struct
       ; in_cps
       ; blocks = p.blocks
       ; closures
-      ; global_context = make_context ()
+      ; global_context = make_context ~value_type:Value.value
       }
     in
     let toplevel_name = Var.fresh_n "toplevel" in

--- a/compiler/lib/wasm/wa_globalize.ml
+++ b/compiler/lib/wasm/wa_globalize.ml
@@ -1,0 +1,103 @@
+(*
+
+Store some toplevel values into globals. Any variable which is used a
+number of instructions after being defined is stored into a global
+instead of a local. The goals are the following:
+- Turn a large number of closures into constant closures, which has a
+  significant impact on performance
+- Reduce the compilation time of the toplevel function in case the
+  Wasm engine decide to optimize it: reduce the register pressure by
+  avoiding long-lived registers in the toplevel function, and make
+  load elimination less expensive by reducing the number of constant
+  structures defined in this function.
+*)
+
+open Stdlib
+
+type st =
+  { pos : int
+  ; visited_variables : int Code.Var.Map.t
+  ; globals : Code.Var.Set.t
+  ; closures : Wa_closure_conversion.closure Code.Var.Map.t
+  }
+
+let threshold = 1000
+
+let rec globalize st x =
+  if Code.Var.Set.mem x st.globals
+  then st
+  else
+    let st = { st with globals = Code.Var.Set.add x st.globals } in
+    globalize_closure st x
+
+and globalize_closure st x =
+  (* If a function is stored in a global variable, its free variables
+     are also stored in a global variable, since they are retained
+     anyway. *)
+  match Code.Var.Map.find x st.closures with
+  | { free_variables; _ } ->
+      List.fold_left
+        ~f:(fun st x ->
+          if Code.Var.Map.mem x st.visited_variables then globalize st x else st)
+        ~init:st
+        free_variables
+  | exception Not_found -> st
+
+let use x st =
+  match Code.Var.Map.find x st.visited_variables with
+  | pos -> if st.pos > pos + threshold then globalize st x else st
+  | exception Not_found -> st
+
+let declare x st =
+  { st with visited_variables = Code.Var.Map.add x st.pos st.visited_variables }
+
+let traverse_expression x e st =
+  match e with
+  | Code.Apply { f; args; _ } ->
+      st |> use f |> fun st -> List.fold_left ~f:(fun st x -> use x st) ~init:st args
+  | Block (_, a, _) -> Array.fold_right ~f:use a ~init:st
+  | Field (x, _) -> st |> use x
+  | Closure _ ->
+      List.fold_left
+        ~f:(fun st x -> use x st)
+        ~init:st
+        (Code.Var.Map.find x st.closures).Wa_closure_conversion.free_variables
+  | Constant _ -> st
+  | Prim (_, args) ->
+      List.fold_left
+        ~f:(fun st a ->
+          match a with
+          | Code.Pv x -> st |> use x
+          | Pc _ -> st)
+        ~init:st
+        args
+
+let traverse_instruction st i =
+  let st = { st with pos = st.pos + 1 } in
+  match fst i with
+  | Code.Let (x, e) -> st |> declare x |> traverse_expression x e
+  | Assign (_, x) | Offset_ref (x, _) -> st |> use x
+  | Set_field (x, _, y) -> st |> use x |> use y
+  | Array_set (x, y, z) -> st |> use x |> use y |> use z
+
+let traverse_block p st pc =
+  let b = Code.Addr.Map.find pc p.Code.blocks in
+  let st = List.fold_left ~f:(fun st x -> declare x st) ~init:st b.Code.params in
+  List.fold_left ~f:(fun st i -> traverse_instruction st i) ~init:st b.Code.body
+
+let f p g closures =
+  let l = Wa_structure.blocks_in_reverse_post_order g in
+  let in_loop = Freevars.find_loops_in_closure p p.Code.start in
+  let st =
+    List.fold_left
+      ~f:(fun st pc ->
+        if Code.Addr.Map.mem pc in_loop then st else traverse_block p st pc)
+      ~init:
+        { pos = 0
+        ; visited_variables = Code.Var.Map.empty
+        ; globals = Code.Var.Set.empty
+        ; closures
+        }
+      l
+  in
+  st.globals

--- a/compiler/lib/wasm/wa_globalize.mli
+++ b/compiler/lib/wasm/wa_globalize.mli
@@ -1,0 +1,5 @@
+val f :
+     Code.program
+  -> Wa_structure.control_flow_graph
+  -> Wa_closure_conversion.closure Code.Var.Map.t
+  -> Code.Var.Set.t

--- a/compiler/lib/wasm/wa_structure.ml
+++ b/compiler/lib/wasm/wa_structure.ml
@@ -146,6 +146,8 @@ let sort_in_post_order g l =
       compare (Hashtbl.find g.block_order b') (Hashtbl.find g.block_order b))
     l
 
+let blocks_in_reverse_post_order g = g.reverse_post_order
+
 (* Compute a map from each block to the set of loops it belongs to *)
 let mark_loops g =
   let in_loop = Hashtbl.create 16 in

--- a/compiler/lib/wasm/wa_structure.mli
+++ b/compiler/lib/wasm/wa_structure.mli
@@ -15,3 +15,5 @@ val is_merge_node : control_flow_graph -> Code.Addr.t -> bool
 val is_backward : control_flow_graph -> Code.Addr.t -> Code.Addr.t -> bool
 
 val sort_in_post_order : control_flow_graph -> Code.Addr.t list -> Code.Addr.t list
+
+val blocks_in_reverse_post_order : control_flow_graph -> Code.Addr.t list


### PR DESCRIPTION
Any variable which is used a number of instructions after being defined is stored into a global
instead of a local. The goals are the following:
- Turn a large number of closures into constant closures, which has a significant impact on performance
- Reduce the compilation time of the toplevel function in case the Wasm engine decide to optimize it: reduce the register pressure by avoiding long-lived registers in the toplevel function, and make load elimination less expensive by reducing the number of constant structures defined in this function.
This also improves binaryen's compilation time.