### PR TITLE
Separate compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Pin dune
         run: |
-          opam pin add -n dune.3.13 https://github.com/ocaml-wasm/dune.git#wasm
+          opam pin add -n dune.3.13 https://github.com/ocaml-wasm/dune.git#wasm-separate-compilation
 
       - name: Pin wasm_of_ocaml
         working-directory: ./wasm_of_ocaml

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -251,7 +251,7 @@ let run
    then (
      let prims = Primitive.get_external () |> StringSet.elements in
      assert (List.length prims > 0);
-     let code, uinfo = Parse_bytecode.predefined_exceptions () in
+     let code, uinfo = Parse_bytecode.predefined_exceptions ~target:`JavaScript in
      let uinfo = { uinfo with primitives = uinfo.primitives @ prims } in
      let code : Parse_bytecode.one =
        { code

--- a/compiler/bin-wasm_of_ocaml/build_runtime.ml
+++ b/compiler/bin-wasm_of_ocaml/build_runtime.ml
@@ -1,6 +1,6 @@
 (* Js_of_ocaml compiler
  * http://www.ocsigen.org/js_of_ocaml/
- * Copyright (C) 2014 Hugo Heuzard
+ * Copyright (C) 2020 Hugo Heuzard
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -17,23 +17,17 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-open Js_of_ocaml_compiler
+open! Js_of_ocaml_compiler.Stdlib
 
-type t =
-  { common : Jsoo_cmdline.Arg.t
-  ; (* compile option *)
-    profile : Driver.profile option
-  ; runtime_files : string list
-  ; runtime_only : bool
-  ; output_file : string * bool
-  ; input_file : string option
-  ; enable_source_maps : bool
-  ; sourcemap_root : string option
-  ; sourcemap_don't_inline_content : bool
-  ; params : (string * string) list
-  ; include_dirs : string list
-  }
+let info =
+  Info.make
+    ~name:"build-runtime"
+    ~doc:"Build standalone runtime. Used for separate compilation."
+    ~description:
+      "Js_of_ocaml is a compiler from OCaml bytecode to Javascript. It makes it possible \
+       to run pure OCaml programs in JavaScript environments like web browsers and \
+       Node.js."
 
-val options : t Cmdliner.Term.t
-
-val options_runtime_only : t Cmdliner.Term.t
+let command =
+  let t = Cmdliner.Term.(const Compile.run $ Cmd_arg.options_runtime_only) in
+  Cmdliner.Cmd.v info t

--- a/compiler/bin-wasm_of_ocaml/build_runtime.mli
+++ b/compiler/bin-wasm_of_ocaml/build_runtime.mli
@@ -1,6 +1,6 @@
 (* Js_of_ocaml compiler
  * http://www.ocsigen.org/js_of_ocaml/
- * Copyright (C) 2014 Hugo Heuzard
+ * Copyright (C) 2020 Hugo Heuzard
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -17,23 +17,4 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-open Js_of_ocaml_compiler
-
-type t =
-  { common : Jsoo_cmdline.Arg.t
-  ; (* compile option *)
-    profile : Driver.profile option
-  ; runtime_files : string list
-  ; runtime_only : bool
-  ; output_file : string * bool
-  ; input_file : string option
-  ; enable_source_maps : bool
-  ; sourcemap_root : string option
-  ; sourcemap_don't_inline_content : bool
-  ; params : (string * string) list
-  ; include_dirs : string list
-  }
-
-val options : t Cmdliner.Term.t
-
-val options_runtime_only : t Cmdliner.Term.t
+val command : unit Cmdliner.Cmd.t

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -222,7 +222,12 @@ let run
         one.debug
         code
     in
-    let generated_js = Wa_generate.f ch ~debug ~live_vars ~in_cps p in
+    let context = Wa_generate.start () in
+    let toplevel_name, generated_js =
+      Wa_generate.f ~context ~unit_name:None ~live_vars ~in_cps p
+    in
+    Wa_generate.add_start_function ~context toplevel_name;
+    Wa_generate.output ch ~context ~debug;
     if times () then Format.eprintf "compilation: %a@." Timer.print t;
     generated_js
   in

--- a/compiler/bin-wasm_of_ocaml/link.ml
+++ b/compiler/bin-wasm_of_ocaml/link.ml
@@ -1,0 +1,87 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2020 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open! Js_of_ocaml_compiler.Stdlib
+open Wasm_of_ocaml_compiler
+open Cmdliner
+
+type t =
+  { common : Jsoo_cmdline.Arg.t
+  ; files : string list
+  ; output_file : string
+  ; linkall : bool
+  ; enable_source_maps : bool
+  }
+
+let options =
+  let output_file =
+    let doc = "Set output file name to [$(docv)]." in
+    Arg.(required & opt (some string) None & info [ "o" ] ~docv:"FILE" ~doc)
+  in
+  let no_sourcemap =
+    let doc = "Disable sourcemap output." in
+    Arg.(value & flag & info [ "no-sourcemap"; "no-source-map" ] ~doc)
+  in
+  let sourcemap =
+    let doc = "Output source locations." in
+    Arg.(value & flag & info [ "sourcemap"; "source-map"; "source-map-inline" ] ~doc)
+  in
+  let files =
+    let doc =
+      "Link the archive files [$(docv)]. The first archive must be a runtime produced by \
+       $(b,wasm_of_ocaml build-runtime). The other archives can be produced by compiling \
+       .cma or .cmo files."
+    in
+    Arg.(non_empty & pos_all string [] & info [] ~docv:"FILES" ~doc)
+  in
+  let linkall =
+    let doc = "Link all compilation units." in
+    Arg.(value & flag & info [ "linkall" ] ~doc)
+  in
+  let build_t common no_sourcemap sourcemap output_file files linkall =
+    let enable_source_maps = (not no_sourcemap) && sourcemap in
+    `Ok { common; output_file; files; linkall; enable_source_maps }
+  in
+  let t =
+    Term.(
+      const build_t
+      $ Jsoo_cmdline.Arg.t
+      $ no_sourcemap
+      $ sourcemap
+      $ output_file
+      $ files
+      $ linkall)
+  in
+  Term.ret t
+
+let f { common; output_file; files; linkall; enable_source_maps } =
+  Jsoo_cmdline.Arg.eval common;
+  Wa_link.link ~output_file ~linkall ~enable_source_maps ~files
+
+let info =
+  Info.make
+    ~name:"link"
+    ~doc:"Wasm_of_ocaml linker"
+    ~description:
+      "wasm_of_ocaml-link is a JavaScript linker. It can concatenate multiple JavaScript \
+       files keeping sourcemap information."
+
+let command =
+  let t = Cmdliner.Term.(const f $ options) in
+  Cmdliner.Cmd.v info t

--- a/compiler/bin-wasm_of_ocaml/link.mli
+++ b/compiler/bin-wasm_of_ocaml/link.mli
@@ -1,6 +1,6 @@
 (* Js_of_ocaml compiler
  * http://www.ocsigen.org/js_of_ocaml/
- * Copyright (C) 2014 Hugo Heuzard
+ * Copyright (C) 2020 Hugo Heuzard
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -17,23 +17,4 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-open Js_of_ocaml_compiler
-
-type t =
-  { common : Jsoo_cmdline.Arg.t
-  ; (* compile option *)
-    profile : Driver.profile option
-  ; runtime_files : string list
-  ; runtime_only : bool
-  ; output_file : string * bool
-  ; input_file : string option
-  ; enable_source_maps : bool
-  ; sourcemap_root : string option
-  ; sourcemap_don't_inline_content : bool
-  ; params : (string * string) list
-  ; include_dirs : string list
-  }
-
-val options : t Cmdliner.Term.t
-
-val options_runtime_only : t Cmdliner.Term.t
+val command : unit Cmdliner.Cmd.t

--- a/compiler/bin-wasm_of_ocaml/wasm_of_ocaml.ml
+++ b/compiler/bin-wasm_of_ocaml/wasm_of_ocaml.ml
@@ -50,7 +50,7 @@ let () =
         (Cmdliner.Cmd.group
            ~default:Compile.term
            (Compile.info "wasm_of_ocaml")
-           [ Compile.command ])
+           [ Link.command; Build_runtime.command; Compile.command ])
     with
     | Ok (`Ok () | `Help | `Version) ->
         if !warnings > 0 && !werror

--- a/compiler/lib/build_info.ml
+++ b/compiler/lib/build_info.ml
@@ -90,6 +90,17 @@ let parse s =
       in
       Some t
 
+let to_json info : Yojson.Basic.t =
+  `Assoc (info |> StringMap.bindings |> List.map ~f:(fun (k, v) -> k, `String v))
+
+let from_json (info : Yojson.Basic.t) =
+  let open Yojson.Basic.Util in
+  info
+  |> to_assoc
+  |> List.fold_left
+       ~f:(fun m (k, v) -> StringMap.add k (to_string v) m)
+       ~init:StringMap.empty
+
 exception
   Incompatible_build_info of
     { key : string

--- a/compiler/lib/build_info.mli
+++ b/compiler/lib/build_info.mli
@@ -34,6 +34,10 @@ val to_string : t -> string
 
 val parse : string -> t option
 
+val to_json : t -> Yojson.Basic.t
+
+val from_json : Yojson.Basic.t -> t
+
 val with_kind : t -> kind -> t
 
 exception

--- a/compiler/lib/fs.mli
+++ b/compiler/lib/fs.mli
@@ -21,3 +21,9 @@ val find_in_path : string list -> string -> string option
 val absolute_path : string -> string
 
 val read_file : string -> string
+
+val write_file : name:string -> contents:string -> unit
+
+val gen_file : string -> (string -> 'a) -> 'a
+
+val with_intermediate_file : string -> (string -> 'a) -> 'a

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -2681,7 +2681,7 @@ let from_exe
     Array.fold_right_i globals.constants ~init:body ~f:(fun i _ l ->
         match globals.vars.(i) with
         | Some x when globals.is_const.(i) ->
-            let l = register_global globals ~target i noloc l in
+            let l = register_global ~target globals i noloc l in
             (Let (x, Constant globals.constants.(i)), noloc) :: l
         | _ -> l)
   in

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -757,8 +757,25 @@ let access_global g i =
       g.vars.(i) <- Some x;
       x
 
-let register_global ?(force = false) g i loc rem =
-  if force || g.is_exported.(i)
+let register_global ~target ?(force = false) g i loc rem =
+  if g.is_exported.(i)
+     &&
+     match target with
+     | `Wasm -> true
+     | `JavaScript -> false
+  then (
+    let name =
+      match g.named_value.(i) with
+      | None -> assert false
+      | Some name -> name
+    in
+    Code.Var.name (access_global g i) name;
+    ( Let
+        ( Var.fresh ()
+        , Prim (Extern "caml_set_global", [ Pc (String name); Pv (access_global g i) ]) )
+    , loc )
+    :: rem)
+  else if force || g.is_exported.(i)
   then
     let args =
       match g.named_value.(i) with
@@ -776,25 +793,40 @@ let register_global ?(force = false) g i loc rem =
     :: rem
   else rem
 
-let get_global state instrs i loc =
+let get_global ~target state instrs i loc =
   State.size_globals state (i + 1);
   let g = State.globals state in
   match g.vars.(i) with
   | Some x ->
       if debug_parser () then Format.printf "(global access %a)@." Var.print x;
       x, State.set_accu state x loc, instrs
-  | None ->
+  | None -> (
       if i < Array.length g.constants && Constants.inlined g.constants.(i)
       then
         let x, state = State.fresh_var state loc in
         let cst = g.constants.(i) in
         x, state, (Let (x, Constant cst), loc) :: instrs
-      else (
+      else if i < Array.length g.constants
+              ||
+              match target with
+              | `Wasm -> false
+              | `JavaScript -> true
+      then (
         g.is_const.(i) <- true;
         let x, state = State.fresh_var state loc in
         if debug_parser () then Format.printf "%a = CONST(%d)@." Var.print x i;
         g.vars.(i) <- Some x;
         x, state, instrs)
+      else
+        match g.named_value.(i) with
+        | None -> assert false
+        | Some name ->
+            let x, state = State.fresh_var state loc in
+            if debug_parser () then Format.printf "%a = get_global(%s)@." Var.print x name;
+            ( x
+            , state
+            , (Let (x, Prim (Extern "caml_get_global", [ Pc (String name) ])), loc)
+              :: instrs ))
 
 let tagged_blocks = ref Addr.Set.empty
 
@@ -811,6 +843,7 @@ type compile_info =
   ; code : string
   ; limit : int
   ; debug : Debug.t
+  ; target : [ `JavaScript | `Wasm ]
   }
 
 let string_of_addr debug_data addr =
@@ -838,7 +871,7 @@ let ( ||| ) x y =
   | No -> y
   | _ -> x
 
-let rec compile_block blocks debug_data code pc state =
+let rec compile_block blocks debug_data ~target code pc state =
   if not (Addr.Set.mem pc !tagged_blocks)
   then (
     let limit = Blocks.next blocks pc in
@@ -847,19 +880,21 @@ let rec compile_block blocks debug_data code pc state =
     let state = State.start_block pc state in
     tagged_blocks := Addr.Set.add pc !tagged_blocks;
     let instr, last, state' =
-      compile { blocks; code; limit; debug = debug_data } pc state []
+      compile { blocks; code; limit; debug = debug_data; target } pc state []
     in
     assert (not (Addr.Map.mem pc !compiled_blocks));
     compiled_blocks := Addr.Map.add pc (state, List.rev instr, last) !compiled_blocks;
     match fst last with
     | Branch (pc', _) | Poptrap (pc', _) ->
-        compile_block blocks debug_data code pc' state'
+        compile_block blocks debug_data ~target code pc' state'
     | Cond (_, (pc1, _), (pc2, _)) ->
-        compile_block blocks debug_data code pc1 state';
-        compile_block blocks debug_data code pc2 state'
+        compile_block blocks debug_data ~target code pc1 state';
+        compile_block blocks debug_data ~target code pc2 state'
     | Switch (_, l1, l2) ->
-        Array.iter l1 ~f:(fun (pc', _) -> compile_block blocks debug_data code pc' state');
-        Array.iter l2 ~f:(fun (pc', _) -> compile_block blocks debug_data code pc' state')
+        Array.iter l1 ~f:(fun (pc', _) ->
+            compile_block blocks debug_data ~target code pc' state');
+        Array.iter l2 ~f:(fun (pc', _) ->
+            compile_block blocks debug_data ~target code pc' state')
     | Pushtrap _ | Raise _ | Return _ | Stop -> ())
 
 and compile infos pc state instrs =
@@ -1195,7 +1230,7 @@ and compile infos pc state instrs =
         let params, state' = State.make_stack nparams state' loc in
         if debug_parser () then Format.printf ") {@.";
         let state' = State.clear_accu state' in
-        compile_block infos.blocks infos.debug code addr state';
+        compile_block infos.blocks infos.debug ~target:infos.target code addr state';
         if debug_parser () then Format.printf "}@.";
         let args = State.stack_vars state' in
         let state'', _, _ = Addr.Map.find addr !compiled_blocks in
@@ -1252,7 +1287,7 @@ and compile infos pc state instrs =
               let params, state' = State.make_stack nparams state' loc in
               if debug_parser () then Format.printf ") {@.";
               let state' = State.clear_accu state' in
-              compile_block infos.blocks infos.debug code addr state';
+              compile_block infos.blocks infos.debug ~target:infos.target code addr state';
               if debug_parser () then Format.printf "}@.";
               let args = State.stack_vars state' in
               let state'', _, _ = Addr.Map.find addr !compiled_blocks in
@@ -1282,16 +1317,16 @@ and compile infos pc state instrs =
         compile infos (pc + 2) (State.env_acc n state) instrs
     | GETGLOBAL ->
         let i = getu code (pc + 1) in
-        let _, state, instrs = get_global state instrs i loc in
+        let _, state, instrs = get_global ~target:infos.target state instrs i loc in
         compile infos (pc + 2) state instrs
     | PUSHGETGLOBAL ->
         let state = State.push state loc in
         let i = getu code (pc + 1) in
-        let _, state, instrs = get_global state instrs i loc in
+        let _, state, instrs = get_global ~target:infos.target state instrs i loc in
         compile infos (pc + 2) state instrs
     | GETGLOBALFIELD ->
         let i = getu code (pc + 1) in
-        let x, state, instrs = get_global state instrs i loc in
+        let x, state, instrs = get_global ~target:infos.target state instrs i loc in
         let j = getu code (pc + 2) in
         let y, state = State.fresh_var state loc in
         if debug_parser () then Format.printf "%a = %a[%d]@." Var.print y Var.print x j;
@@ -1300,7 +1335,7 @@ and compile infos pc state instrs =
         let state = State.push state loc in
 
         let i = getu code (pc + 1) in
-        let x, state, instrs = get_global state instrs i loc in
+        let x, state, instrs = get_global ~target:infos.target state instrs i loc in
         let j = getu code (pc + 2) in
         let y, state = State.fresh_var state loc in
         if debug_parser () then Format.printf "%a = %a[%d]@." Var.print y Var.print x j;
@@ -1325,7 +1360,7 @@ and compile infos pc state instrs =
         in
         let x, state = State.fresh_var state loc in
         if debug_parser () then Format.printf "%a = 0@." Var.print x;
-        let instrs = register_global g i loc instrs in
+        let instrs = register_global ~target:infos.target g i loc instrs in
         compile infos (pc + 2) state ((Let (x, const 0l), loc) :: instrs)
     | ATOM0 ->
         let x, state = State.fresh_var state loc in
@@ -1696,10 +1731,17 @@ and compile infos pc state instrs =
                   , Addr.Set.empty )
               , loc ) )
             !compiled_blocks;
-        compile_block infos.blocks infos.debug code handler_addr handler_state;
         compile_block
           infos.blocks
           infos.debug
+          ~target:infos.target
+          code
+          handler_addr
+          handler_state;
+        compile_block
+          infos.blocks
+          infos.debug
+          ~target:infos.target
           code
           body_addr
           { (State.push_handler handler_ctx_state) with
@@ -1723,6 +1765,7 @@ and compile infos pc state instrs =
         compile_block
           infos.blocks
           infos.debug
+          ~target:infos.target
           code
           addr
           (State.pop 4 (State.pop_handler state));
@@ -2426,7 +2469,7 @@ type one =
   ; debug : Debug.t
   }
 
-let parse_bytecode code globals debug_data =
+let parse_bytecode code globals debug_data ~target =
   let state = State.initial globals in
   Code.Var.reset ();
   let blocks = Blocks.analyse debug_data code in
@@ -2441,7 +2484,7 @@ let parse_bytecode code globals debug_data =
     if not (Blocks.is_empty blocks')
     then (
       let start = 0 in
-      compile_block blocks' debug_data code start state;
+      compile_block blocks' debug_data ~target code start state;
       let blocks =
         Addr.Map.mapi
           (fun _ (state, instr, last) ->
@@ -2625,12 +2668,12 @@ let from_exe
     Ocaml_compiler.Symtable.GlobalMap.iter symbols ~f:(fun id n ->
         globals.named_value.(n) <- Some (Ocaml_compiler.Symtable.Global.name id);
         globals.is_exported.(n) <- true);
-  let p = parse_bytecode code globals debug_data in
+  let p = parse_bytecode code globals debug_data ~target in
   (* register predefined exception *)
   let body =
     List.fold_left predefined_exceptions ~init:[] ~f:(fun body (i, name) ->
         globals.named_value.(i) <- Some name;
-        let body = register_global ~force:true globals i noloc body in
+        let body = register_global ~target ~force:true globals i noloc body in
         globals.is_exported.(i) <- false;
         body)
   in
@@ -2638,7 +2681,7 @@ let from_exe
     Array.fold_right_i globals.constants ~init:body ~f:(fun i _ l ->
         match globals.vars.(i) with
         | Some x when globals.is_const.(i) ->
-            let l = register_global globals i noloc l in
+            let l = register_global globals ~target i noloc l in
             (Let (x, Constant globals.constants.(i)), noloc) :: l
         | _ -> l)
   in
@@ -2754,7 +2797,7 @@ let from_bytes ~prims ~debug (code : bytecode) =
     t
   in
   let globals = make_globals 0 [||] prims in
-  let p = parse_bytecode code globals debug_data in
+  let p = parse_bytecode code globals debug_data ~target:`JavaScript in
   let gdata = Var.fresh_n "global_data" in
   let need_gdata = ref false in
   let find_name i =
@@ -2902,7 +2945,7 @@ let from_compilation_units ~target ~includes:_ ~include_cmis ~debug_data l =
     let l = List.map l ~f:(fun (_, c) -> Bytes.to_string c) in
     String.concat ~sep:"" l
   in
-  let prog = parse_bytecode code globals debug_data in
+  let prog = parse_bytecode code globals debug_data ~target in
   let gdata = Var.fresh_n "global_data" in
   let need_gdata = ref false in
   let body =
@@ -2911,7 +2954,7 @@ let from_compilation_units ~target ~includes:_ ~include_cmis ~debug_data l =
         | Some x when globals.is_const.(i) -> (
             match globals.named_value.(i) with
             | None ->
-                let l = register_global globals i noloc l in
+                let l = register_global ~target globals i noloc l in
                 let cst = globals.constants.(i) in
                 (match cst, Code.Var.get_name x with
                 | String str, None -> Code.Var.name x (Printf.sprintf "cst_%s" str)
@@ -3026,7 +3069,7 @@ let from_channel ic =
           `Exe
       | _ -> raise Magic_number.(Bad_magic_number (to_string magic)))
 
-let predefined_exceptions () =
+let predefined_exceptions ~target =
   let body =
     let open Code in
     List.map predefined_exceptions ~f:(fun (index, name) ->
@@ -3035,25 +3078,45 @@ let predefined_exceptions () =
         let v_name = Var.fresh () in
         let v_name_js = Var.fresh () in
         let v_index = Var.fresh () in
-        [ Let (v_name, Constant (String name)), noloc
-        ; Let (v_name_js, Constant (NativeString (Native_string.of_string name))), noloc
-        ; ( Let
-              ( v_index
-              , Constant
-                  (Int
-                     ( (* Predefined exceptions are registered in
-                          Symtable.init with [-index - 1] *)
-                       Regular
-                     , Int32.of_int (-index - 1) )) )
-          , noloc )
-        ; Let (exn, Block (248, [| v_name; v_index |], NotArray)), noloc
-        ; ( Let
-              ( Var.fresh ()
-              , Prim
-                  ( Extern "caml_register_global"
-                  , [ Pc (Int (Regular, Int32.of_int index)); Pv exn; Pv v_name_js ] ) )
-          , noloc )
-        ])
+        [ Let (v_name, Constant (String name)), noloc ]
+        @ (match target with
+          | `Wasm -> []
+          | `JavaScript ->
+              [ ( Let (v_name_js, Constant (NativeString (Native_string.of_string name)))
+                , noloc )
+              ])
+        @ [ ( Let
+                ( v_index
+                , Constant
+                    (Int
+                       ( (* Predefined exceptions are registered in
+                            Symtable.init with [-index - 1] *)
+                         Regular
+                       , Int32.of_int (-index - 1) )) )
+            , noloc )
+          ; Let (exn, Block (248, [| v_name; v_index |], NotArray)), noloc
+          ; ( Let
+                ( Var.fresh ()
+                , Prim
+                    ( Extern "caml_register_global"
+                    , [ Pc (Int (Regular, Int32.of_int index))
+                      ; Pv exn
+                      ; Pv
+                          (match target with
+                          | `JavaScript -> v_name_js
+                          | `Wasm -> v_name)
+                      ] ) )
+            , noloc )
+          ]
+        @
+        match target with
+        | `JavaScript -> []
+        | `Wasm ->
+            [ ( Let
+                  ( Var.fresh ()
+                  , Prim (Extern "caml_set_global", [ Pc (String name); Pv exn ]) )
+              , noloc )
+            ])
     |> List.concat
   in
   let block = { params = []; body; branch = Stop, noloc } in

--- a/compiler/lib/parse_bytecode.mli
+++ b/compiler/lib/parse_bytecode.mli
@@ -90,7 +90,7 @@ val from_string :
   -> string
   -> Code.program * Debug.t
 
-val predefined_exceptions : unit -> Code.program * Unit_info.t
+val predefined_exceptions : target:[ `JavaScript | `Wasm ] -> Code.program * Unit_info.t
 
 val link_info :
      target:[ `JavaScript | `Wasm ]

--- a/compiler/lib/unit_info.ml
+++ b/compiler/lib/unit_info.ml
@@ -140,3 +140,38 @@ let parse acc s =
       | Some ("Effects_without_cps", b) ->
           Some { acc with effects_without_cps = bool_of_string (String.trim b) }
       | Some (_, _) -> None)
+
+let to_json t : Yojson.Basic.t =
+  let add nm skip v rem = if skip then rem else (nm, v) :: rem in
+  let set nm f rem =
+    add
+      nm
+      (List.equal ~eq:String.equal (f empty) (f t))
+      (`List (List.map ~f:(fun x -> `String x) (f t)))
+      rem
+  in
+  let bool nm f rem = add nm (Bool.equal (f empty) (f t)) (`Bool (f t)) rem in
+  `Assoc
+    ([]
+    |> bool "effects_without_cps" (fun t -> t.effects_without_cps)
+    |> set "primitives" (fun t -> t.primitives)
+    |> bool "force_link" (fun t -> t.force_link)
+    |> set "requires" (fun t -> StringSet.elements t.requires)
+    |> add "provides" false (`String (StringSet.choose t.provides)))
+
+let from_json t =
+  let open Yojson.Basic.Util in
+  let opt_list l = l |> to_option to_list |> Option.map ~f:(List.map ~f:to_string) in
+  let list default l = Option.value ~default (opt_list l) in
+  let set default l =
+    Option.value ~default (Option.map ~f:StringSet.of_list (opt_list l))
+  in
+  let bool default v = Option.value ~default (to_option to_bool v) in
+  { provides = t |> member "provides" |> to_string |> StringSet.singleton
+  ; requires = t |> member "requires" |> set empty.requires
+  ; primitives = t |> member "primitives" |> list empty.primitives
+  ; force_link = t |> member "force_link" |> bool empty.force_link
+  ; effects_without_cps =
+      t |> member "effects_without_cps" |> bool empty.effects_without_cps
+  ; crcs = StringMap.empty
+  }

--- a/compiler/lib/unit_info.mli
+++ b/compiler/lib/unit_info.mli
@@ -39,3 +39,7 @@ val prefix : string
 val to_string : t -> string
 
 val parse : t -> string -> t option
+
+val to_json : t -> Yojson.Basic.t
+
+val from_json : Yojson.Basic.t -> t

--- a/compiler/lib/wasm/wa_ast.ml
+++ b/compiler/lib/wasm/wa_ast.ml
@@ -227,6 +227,7 @@ type module_field =
       }
   | Global of
       { name : symbol
+      ; exported_name : string option
       ; typ : global_type
       ; init : expression
       }

--- a/compiler/lib/wasm/wa_ast.ml
+++ b/compiler/lib/wasm/wa_ast.ml
@@ -129,8 +129,8 @@ type expression =
   | F64PromoteF32 of expression
   | Load of (memarg, memarg, memarg, memarg) op * expression
   | Load8 of signage * (memarg, memarg, memarg, memarg) op * expression
-  | LocalGet of int
-  | LocalTee of int * expression
+  | LocalGet of var
+  | LocalTee of var * expression
   | GlobalGet of symbol
   | BlockExpr of func_type * instruction list
   | Call_indirect of func_type * expression * expression list
@@ -163,7 +163,7 @@ and instruction =
   | Drop of expression
   | Store of (memarg, memarg, memarg, memarg) op * expression * expression
   | Store8 of (memarg, memarg, memarg, memarg) op * expression * expression
-  | LocalSet of int * expression
+  | LocalSet of var * expression
   | GlobalSet of symbol * expression
   | Loop of func_type * instruction list
   | Block of func_type * instruction list
@@ -215,7 +215,8 @@ type module_field =
       { name : var
       ; exported_name : string option
       ; typ : func_type
-      ; locals : value_type list
+      ; param_names : var list
+      ; locals : (var * value_type) list
       ; body : instruction list
       }
   | Data of

--- a/compiler/lib/wasm/wa_binaryen.ml
+++ b/compiler/lib/wasm/wa_binaryen.ml
@@ -1,0 +1,118 @@
+open Stdlib
+
+let debug = Debug.find "binaryen"
+
+let command cmdline =
+  let cmdline = String.concat ~sep:" " cmdline in
+  if debug () then Format.eprintf "+ %s@." cmdline;
+  let res = Sys.command cmdline in
+  if res <> 0 then failwith ("the following command terminated unsuccessfully: " ^ cmdline)
+
+let common_options () =
+  let l =
+    [ "--enable-gc"
+    ; "--enable-multivalue"
+    ; "--enable-exception-handling"
+    ; "--enable-reference-types"
+    ; "--enable-tail-call"
+    ; "--enable-bulk-memory"
+    ; "--enable-nontrapping-float-to-int"
+    ; "--enable-strings"
+    ]
+  in
+  if Config.Flag.pretty () then "-g" :: l else l
+
+let opt_flag flag v =
+  match v with
+  | None -> []
+  | Some v -> [ flag; Filename.quote v ]
+
+let link ~runtime_files ~input_files ~opt_output_sourcemap ~output_file =
+  command
+    ("wasm-merge"
+    :: (common_options ()
+       @ List.flatten
+           (List.map
+              ~f:(fun runtime_file -> [ Filename.quote runtime_file; "env" ])
+              runtime_files)
+       @ List.flatten
+           (List.map
+              ~f:(fun input_file -> [ Filename.quote input_file; "OCaml" ])
+              input_files)
+       @ [ "-o"; Filename.quote output_file ]
+       @ opt_flag "--output-source-map" opt_output_sourcemap))
+
+let generate_dependencies ~dependencies primitives =
+  Yojson.Basic.to_string
+    (`List
+      (StringSet.fold
+         (fun nm s ->
+           `Assoc
+             [ "name", `String ("js:" ^ nm)
+             ; "import", `List [ `String "js"; `String nm ]
+             ]
+           :: s)
+         primitives
+         (Yojson.Basic.Util.to_list (Yojson.Basic.from_string dependencies))))
+
+let filter_unused_primitives primitives usage_file =
+  let ch = open_in usage_file in
+  let s = ref primitives in
+  (try
+     while true do
+       let l = input_line ch in
+       match String.drop_prefix ~prefix:"unused: js:" l with
+       | Some nm -> s := StringSet.remove nm !s
+       | None -> ()
+     done
+   with End_of_file -> ());
+  !s
+
+let dead_code_elimination
+    ~dependencies
+    ~opt_input_sourcemap
+    ~input_file
+    ~opt_output_sourcemap
+    ~output_file =
+  Fs.with_intermediate_file (Filename.temp_file "deps" ".json")
+  @@ fun deps_file ->
+  Fs.with_intermediate_file (Filename.temp_file "usage" ".txt")
+  @@ fun usage_file ->
+  let primitives = Linker.get_provided () in
+  Fs.write_file ~name:deps_file ~contents:(generate_dependencies ~dependencies primitives);
+  command
+    ("wasm-metadce"
+    :: (common_options ()
+       @ [ "--graph-file"; Filename.quote deps_file; Filename.quote input_file ]
+       @ opt_flag "--input-source-map" opt_input_sourcemap
+       @ [ "-o"; Filename.quote output_file ]
+       @ opt_flag "--output-source-map" opt_output_sourcemap
+       @ [ ">"; Filename.quote usage_file ]));
+  filter_unused_primitives primitives usage_file
+
+let optimization_options =
+  [| [ "-O2"; "--skip-pass=inlining-optimizing"; "--traps-never-happen" ]
+   ; [ "-O2"; "--traps-never-happen" ]
+   ; [ "-O3"; "--traps-never-happen" ]
+  |]
+
+let optimize
+    ~profile
+    ~opt_input_sourcemap
+    ~input_file
+    ~opt_output_sourcemap
+    ~opt_sourcemap_url
+    ~output_file =
+  let level =
+    match profile with
+    | None -> 1
+    | Some p -> fst (List.find ~f:(fun (_, p') -> Poly.equal p p') Driver.profiles)
+  in
+  command
+    ("wasm-opt"
+     :: (common_options ()
+        @ optimization_options.(level - 1)
+        @ [ Filename.quote input_file; "-o"; Filename.quote output_file ])
+    @ opt_flag "--input-source-map" opt_input_sourcemap
+    @ opt_flag "--output-source-map" opt_output_sourcemap
+    @ opt_flag "--output-source-map-url" opt_sourcemap_url)

--- a/compiler/lib/wasm/wa_binaryen.mli
+++ b/compiler/lib/wasm/wa_binaryen.mli
@@ -1,0 +1,23 @@
+val link :
+     runtime_files:string list
+  -> input_files:string list
+  -> opt_output_sourcemap:string option
+  -> output_file:string
+  -> unit
+
+val dead_code_elimination :
+     dependencies:string
+  -> opt_input_sourcemap:string option
+  -> input_file:string
+  -> opt_output_sourcemap:string option
+  -> output_file:string
+  -> Stdlib.StringSet.t
+
+val optimize :
+     profile:Driver.profile option
+  -> opt_input_sourcemap:string option
+  -> input_file:string
+  -> opt_output_sourcemap:string option
+  -> opt_sourcemap_url:string option
+  -> output_file:string
+  -> unit

--- a/compiler/lib/wasm/wa_code_generation.ml
+++ b/compiler/lib/wasm/wa_code_generation.ml
@@ -157,8 +157,9 @@ let heap_type_sub (ty : W.heap_type) (ty' : W.heap_type) st =
   (* I31, struct and arrays have no subtype (of a different kind) *)
   | _, (I31 | Type _) -> false, st
 
-let register_global name ?(constant = false) typ init st =
-  st.context.other_fields <- W.Global { name; typ; init } :: st.context.other_fields;
+let register_global name ?exported_name ?(constant = false) typ init st =
+  st.context.other_fields <-
+    W.Global { name; exported_name; typ; init } :: st.context.other_fields;
   (match name with
   | S _ -> ()
   | V name ->

--- a/compiler/lib/wasm/wa_code_generation.ml
+++ b/compiler/lib/wasm/wa_code_generation.ml
@@ -41,6 +41,7 @@ type context =
   ; mutable fragments : Javascript.expression StringMap.t
   ; mutable globalized_variables : Var.Set.t
   ; value_type : W.value_type
+  ; mutable unit_name : string option
   }
 
 let make_context ~value_type =
@@ -65,6 +66,7 @@ let make_context ~value_type =
   ; fragments = StringMap.empty
   ; globalized_variables = Var.Set.empty
   ; value_type
+  ; unit_name = None
   }
 
 type var =
@@ -241,6 +243,8 @@ let set_closure_env f env st =
 let get_closure_env f st = Var.Map.find f st.context.closure_envs, st
 
 let is_closure f st = Var.Map.mem f st.context.closure_envs, st
+
+let unit_name st = st.context.unit_name, st
 
 let var x st =
   try Var.Map.find x st.vars, st

--- a/compiler/lib/wasm/wa_code_generation.mli
+++ b/compiler/lib/wasm/wa_code_generation.mli
@@ -25,6 +25,7 @@ type context =
   ; mutable fragments : Javascript.expression StringMap.t
   ; mutable globalized_variables : Code.Var.Set.t
   ; value_type : Wa_ast.value_type
+  ; mutable unit_name : string option
   }
 
 val make_context : value_type:Wa_ast.value_type -> context
@@ -163,6 +164,8 @@ val set_closure_env : Code.Var.t -> Code.Var.t -> unit t
 val get_closure_env : Code.Var.t -> Code.Var.t t
 
 val is_closure : Code.Var.t -> bool t
+
+val unit_name : string option t
 
 val need_apply_fun : cps:bool -> arity:int -> Code.Var.t t
 

--- a/compiler/lib/wasm/wa_code_generation.mli
+++ b/compiler/lib/wasm/wa_code_generation.mli
@@ -135,7 +135,12 @@ val register_import :
   ?import_module:string -> name:string -> Wa_ast.import_desc -> Wa_ast.var t
 
 val register_global :
-  Wa_ast.symbol -> ?constant:bool -> Wa_ast.global_type -> Wa_ast.expression -> unit t
+     Wa_ast.symbol
+  -> ?exported_name:string
+  -> ?constant:bool
+  -> Wa_ast.global_type
+  -> Wa_ast.expression
+  -> unit t
 
 val get_global : Code.Var.t -> Wa_ast.expression option t
 

--- a/compiler/lib/wasm/wa_code_generation.mli
+++ b/compiler/lib/wasm/wa_code_generation.mli
@@ -111,13 +111,13 @@ val if_ : Wa_ast.func_type -> expression -> unit t -> unit t -> unit t
 
 val try_ : Wa_ast.func_type -> unit t -> (Code.Var.t * unit t) list -> unit t
 
-val add_var : ?typ:Wa_ast.value_type -> Wa_ast.var -> int t
+val add_var : ?typ:Wa_ast.value_type -> Wa_ast.var -> Wa_ast.var t
 
 val define_var : Wa_ast.var -> expression -> unit t
 
 val is_small_constant : Wa_ast.expression -> bool t
 
-val get_i31_value : int -> int option t
+val get_i31_value : Wa_ast.var -> Wa_ast.var option t
 
 val with_location : Code.loc -> unit t -> unit t
 
@@ -167,6 +167,6 @@ val need_dummy_fun : cps:bool -> arity:int -> Code.Var.t t
 
 val function_body :
      context:context
-  -> param_count:int
+  -> param_names:Code.Var.t list
   -> body:unit t
-  -> Wa_ast.value_type list * Wa_ast.instruction list
+  -> (Wa_ast.var * Wa_ast.value_type) list * Wa_ast.instruction list

--- a/compiler/lib/wasm/wa_core_target.ml
+++ b/compiler/lib/wasm/wa_core_target.ml
@@ -640,7 +640,7 @@ let handle_exceptions ~result_typ ~fall_through ~context body x exn_handler =
 
 let post_process_function_body ~param_names:_ ~locals:_ instrs = instrs
 
-let entry_point ~context:_ ~toplevel_fun =
+let entry_point ~toplevel_fun =
   let code =
     let declare_global name =
       register_global (S name) { mut = true; typ = I32 } (Const (I32 0l))

--- a/compiler/lib/wasm/wa_core_target.ml
+++ b/compiler/lib/wasm/wa_core_target.ml
@@ -632,7 +632,7 @@ let handle_exceptions ~result_typ ~fall_through ~context body x exn_handler =
         exn_handler ~result_typ ~fall_through ~context )
     ]
 
-let post_process_function_body ~param_count:_ ~locals:_ instrs = instrs
+let post_process_function_body ~param_names:_ ~locals:_ instrs = instrs
 
 let entry_point ~context:_ ~toplevel_fun =
   let code =
@@ -653,4 +653,4 @@ let entry_point ~context:_ ~toplevel_fun =
     let* () = instr (W.GlobalSet (S "young_limit", low)) in
     drop (return (W.Call (toplevel_fun, [])))
   in
-  { W.params = []; result = [] }, code
+  { W.params = []; result = [] }, [], code

--- a/compiler/lib/wasm/wa_core_target.ml
+++ b/compiler/lib/wasm/wa_core_target.ml
@@ -270,7 +270,13 @@ end
 module Value = struct
   let value : W.value_type = I32
 
+  let block_type = return value
+
   let unit = Arith.const 1l
+
+  let dummy_block = unit
+
+  let as_block e = e
 
   let val_int i = Arith.((i lsl const 1l) + const 1l)
 

--- a/compiler/lib/wasm/wa_gc_target.ml
+++ b/compiler/lib/wasm/wa_gc_target.ml
@@ -407,6 +407,19 @@ end
 module Value = struct
   let value = Type.value
 
+  let block_type =
+    let* t = Type.block_type in
+    return (W.Ref { nullable = false; typ = Type t })
+
+  let dummy_block =
+    let* t = Type.block_type in
+    return (W.ArrayNewFixed (t, []))
+
+  let as_block e =
+    let* t = Type.block_type in
+    let* e = e in
+    return (W.RefCast ({ nullable = false; typ = Type t }, e))
+
   let unit = return (W.RefI31 (Const (I32 0l)))
 
   let val_int = Arith.to_int31

--- a/compiler/lib/wasm/wa_generate.mli
+++ b/compiler/lib/wasm/wa_generate.mli
@@ -1,9 +1,21 @@
 val init : unit -> unit
 
+val start : unit -> Wa_code_generation.context
+
 val f :
-     out_channel
+     context:Wa_code_generation.context
+  -> unit_name:string option
   -> Code.program
   -> live_vars:int array
   -> in_cps:Effects.in_cps
+  -> Wa_ast.var * (string list * (string * Javascript.expression) list)
+
+val add_start_function : context:Wa_code_generation.context -> Wa_ast.var -> unit
+
+val add_init_function : context:Wa_code_generation.context -> to_link:string list -> unit
+
+val output :
+     out_channel
+  -> context:Wa_code_generation.context
   -> debug:Parse_bytecode.Debug.t
-  -> string list * (string * Javascript.expression) list
+  -> unit

--- a/compiler/lib/wasm/wa_initialize_locals.mli
+++ b/compiler/lib/wasm/wa_initialize_locals.mli
@@ -1,5 +1,5 @@
 val f :
-     param_count:int
-  -> locals:Wa_ast.value_type list
+     param_names:Wa_ast.var list
+  -> locals:(Wa_ast.var * Wa_ast.value_type) list
   -> Wa_ast.instruction list
   -> Wa_ast.instruction list

--- a/compiler/lib/wasm/wa_link.ml
+++ b/compiler/lib/wasm/wa_link.ml
@@ -148,3 +148,133 @@ module Wasm_binary = struct
     close_in ch.ch;
     res
 end
+
+let output_js js =
+  Code.Var.reset ();
+  let b = Buffer.create 1024 in
+  let f = Pretty_print.to_buffer b in
+  Driver.configure f;
+  let traverse = new Js_traverse.free in
+  let js = traverse#program js in
+  let free = traverse#get_free in
+  Javascript.IdentSet.iter
+    (fun x ->
+      match x with
+      | V _ -> assert false
+      | S { name = Utf8 x; _ } -> Var_printer.add_reserved x)
+    free;
+  let js =
+    if Config.Flag.shortvar () then (new Js_traverse.rename_variable)#program js else js
+  in
+  let js = (new Js_traverse.simpl)#program js in
+  let js = (new Js_traverse.clean)#program js in
+  let js = Js_assign.program js in
+  ignore (Js_output.program f js);
+  Buffer.contents b
+
+let report_missing_primitives missing =
+  if not (List.is_empty missing)
+  then (
+    warn "There are some missing Wasm primitives@.";
+    warn "Dummy implementations (raising an exception) ";
+    warn "will be provided.@.";
+    warn "Missing primitives:@.";
+    List.iter ~f:(fun nm -> warn "  %s@." nm) missing)
+
+let build_runtime_arguments
+    ~missing_primitives
+    ~wasm_file
+    ~generated_js:(strings, fragments) =
+  let missing_primitives = if Config.Flag.genprim () then missing_primitives else [] in
+  report_missing_primitives missing_primitives;
+  let obj l =
+    Javascript.EObj
+      (List.map
+         ~f:(fun (nm, v) ->
+           let id = Utf8_string.of_string_exn nm in
+           Javascript.Property (PNS id, v))
+         l)
+  in
+  let generated_js =
+    let strings =
+      if List.is_empty strings
+      then []
+      else
+        [ ( "strings"
+          , Javascript.EArr
+              (List.map
+                 ~f:(fun s -> Javascript.Element (EStr (Utf8_string.of_string_exn s)))
+                 strings) )
+        ]
+    in
+    let fragments =
+      if List.is_empty fragments then [] else [ "fragments", obj fragments ]
+    in
+    strings @ fragments
+  in
+  let generated_js =
+    if not (List.is_empty missing_primitives)
+    then
+      ( "env"
+      , obj
+          (List.map
+             ~f:(fun nm ->
+               ( nm
+               , Javascript.EArrow
+                   ( Javascript.fun_
+                       []
+                       [ ( Throw_statement
+                             (ENew
+                                ( EVar
+                                    (Javascript.ident (Utf8_string.of_string_exn "Error"))
+                                , Some
+                                    [ Arg
+                                        (EStr
+                                           (Utf8_string.of_string_exn
+                                              (nm ^ " not implemented")))
+                                    ] ))
+                         , N )
+                       ]
+                       N
+                   , AUnknown ) ))
+             missing_primitives) )
+      :: generated_js
+    else generated_js
+  in
+  let generated_js =
+    if List.is_empty generated_js
+    then obj generated_js
+    else
+      let var ident e =
+        Javascript.variable_declaration [ Javascript.ident ident, (e, N) ], Javascript.N
+      in
+      Javascript.call
+        (EArrow
+           ( Javascript.fun_
+               [ Javascript.ident Constant.global_object_ ]
+               [ var
+                   Constant.old_global_object_
+                   (EVar (Javascript.ident Constant.global_object_))
+               ; var
+                   Constant.exports_
+                   (EBin
+                      ( Or
+                      , EDot
+                          ( EDot
+                              ( EVar (Javascript.ident Constant.global_object_)
+                              , ANullish
+                              , Utf8_string.of_string_exn "module" )
+                          , ANullish
+                          , Utf8_string.of_string_exn "export" )
+                      , EVar (Javascript.ident Constant.global_object_) ))
+               ; Return_statement (Some (obj generated_js)), N
+               ]
+               N
+           , AUnknown ))
+        [ EVar (Javascript.ident Constant.global_object_) ]
+        N
+  in
+  obj
+    [ "generated", generated_js
+    ; "src", EStr (Utf8_string.of_string_exn (Filename.basename wasm_file))
+    ]

--- a/compiler/lib/wasm/wa_link.ml
+++ b/compiler/lib/wasm/wa_link.ml
@@ -1,0 +1,150 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2017 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open Stdlib
+
+module Wasm_binary = struct
+  let header = "\000asm\001\000\000\000"
+
+  let check_header file ch =
+    let s = really_input_string ch 8 in
+    if not (String.equal s header)
+    then failwith (file ^ " is not a Wasm binary file (bad magic)")
+
+  type t =
+    { ch : in_channel
+    ; limit : int
+    }
+
+  let open_in f =
+    let ch = open_in_bin f in
+    check_header f ch;
+    { ch; limit = in_channel_length ch }
+
+  let rec read_uint ?(n = 5) ch =
+    let i = input_byte ch in
+    if n = 1 then assert (i < 16);
+    if i < 128 then i else i - 128 + (read_uint ~n:(n - 1) ch lsl 7)
+
+  let rec read_sint ?(n = 5) ch =
+    let i = input_byte ch in
+    if n = 1 then assert (i < 8 || (i > 120 && i < 128));
+    if i < 64
+    then i
+    else if i < 128
+    then i - 128
+    else i - 128 + (read_sint ~n:(n - 1) ch lsl 7)
+
+  type section =
+    { id : int
+    ; size : int
+    }
+
+  let next_section ch =
+    if pos_in ch.ch = ch.limit
+    then None
+    else
+      let id = input_byte ch.ch in
+      let size = read_uint ch.ch in
+      Some { id; size }
+
+  let skip_section ch { size; _ } = seek_in ch.ch (pos_in ch.ch + size)
+
+  let vec f ch =
+    let rec loop acc n = if n = 0 then List.rev acc else loop (f ch :: acc) (n - 1) in
+    loop [] (read_uint ch)
+
+  let name ch =
+    let n = read_uint ch in
+    really_input_string ch n
+
+  let heaptype ch = ignore (read_sint ch)
+
+  let reftype' i ch =
+    match i with
+    | 0x6a | 0x6b | 0x6c | 0x6d | 0x6e | 0x6f | 0x70 | 0x71 | 0x72 | 0x73 -> ()
+    | 0x63 | 0x64 -> heaptype ch
+    | _ ->
+        Format.eprintf "Unknown reftype %x@." i;
+        assert false
+
+  let reftype ch = reftype' (input_byte ch) ch
+
+  let valtype ch =
+    let i = read_uint ch in
+    match i with
+    | 0x7b | 0x7c | 0x7d | 0x7e | 0x7f -> ()
+    | _ -> reftype' i ch
+
+  let limits ch =
+    match input_byte ch with
+    | 0 -> ignore (read_uint ch)
+    | 1 ->
+        ignore (read_uint ch);
+        ignore (read_uint ch)
+    | _ -> assert false
+
+  let memtype = limits
+
+  let tabletype ch =
+    reftype ch;
+    limits ch
+
+  type import =
+    { module_ : string
+    ; name : string
+    }
+
+  let import ch =
+    let module_ = name ch in
+    let name = name ch in
+    let d = read_uint ch in
+    let _ =
+      match d with
+      | 0 -> ignore (read_uint ch)
+      | 1 -> tabletype ch
+      | 2 -> memtype ch
+      | 3 ->
+          let _typ = valtype ch in
+          let _mut = input_byte ch in
+          ()
+      | 4 ->
+          assert (read_uint ch = 0);
+          ignore (read_uint ch)
+      | _ ->
+          Format.eprintf "Unknown import %x@." d;
+          assert false
+    in
+    { module_; name }
+
+  let read_imports ~file =
+    let ch = open_in file in
+    let rec find_section () =
+      match next_section ch with
+      | None -> false
+      | Some s ->
+          s.id = 2
+          ||
+          (skip_section ch s;
+           find_section ())
+    in
+    let res = if find_section () then vec import ch.ch else [] in
+    close_in ch.ch;
+    res
+end

--- a/compiler/lib/wasm/wa_link.ml
+++ b/compiler/lib/wasm/wa_link.ml
@@ -19,6 +19,8 @@
 
 open Stdlib
 
+let times = Debug.find "times"
+
 module Wasm_binary = struct
   let header = "\000asm\001\000\000\000"
 
@@ -36,6 +38,11 @@ module Wasm_binary = struct
     let ch = open_in_bin f in
     check_header f ch;
     { ch; limit = in_channel_length ch }
+
+  let from_channel ~name ch pos len =
+    seek_in ch pos;
+    check_header name ch;
+    { ch; limit = pos + len }
 
   let rec read_uint ?(n = 5) ch =
     let i = input_byte ch in
@@ -133,6 +140,16 @@ module Wasm_binary = struct
     in
     { module_; name }
 
+  let export ch =
+    let name = name ch in
+    let d = read_uint ch in
+    if d > 4
+    then (
+      Format.eprintf "Unknown export %x@." d;
+      assert false);
+    ignore (read_uint ch);
+    name
+
   let read_imports ~file =
     let ch = open_in file in
     let rec find_section () =
@@ -147,7 +164,150 @@ module Wasm_binary = struct
     let res = if find_section () then vec import ch.ch else [] in
     close_in ch.ch;
     res
+
+  type interface =
+    { imports : import list
+    ; exports : string list
+    }
+
+  let read_interface ch =
+    let rec find_sections i =
+      match next_section ch with
+      | None -> i
+      | Some s ->
+          if s.id = 2
+          then find_sections { i with imports = vec import ch.ch }
+          else if s.id = 7
+          then { i with exports = vec export ch.ch }
+          else (
+            skip_section ch s;
+            find_sections i)
+    in
+    find_sections { imports = []; exports = [] }
 end
+
+let trim_semi s =
+  let l = ref (String.length s) in
+  while
+    !l > 0
+    &&
+    match s.[!l - 1] with
+    | ';' | '\n' -> true
+    | _ -> false
+  do
+    decr l
+  done;
+  String.sub s ~pos:0 ~len:!l
+
+type unit_data =
+  { unit_info : Unit_info.t
+  ; strings : string list
+  ; fragments : (string * Javascript.expression) list
+  }
+
+let info_to_json ~predefined_exceptions ~build_info ~unit_data =
+  let add nm skip v rem = if skip then rem else (nm, v) :: rem in
+  let units =
+    List.map
+      ~f:(fun { unit_info; strings; fragments } ->
+        `Assoc
+          (Unit_info.to_json unit_info
+          |> Yojson.Basic.Util.to_assoc
+          |> add
+               "strings"
+               (List.is_empty strings)
+               (`List (List.map ~f:(fun s -> `String s) strings))
+          |> add
+               "fragments"
+               (List.is_empty fragments)
+               (`String (Marshal.to_string fragments []))))
+      unit_data
+  in
+  `Assoc
+    ([]
+    |> add
+         "predefined_exceptions"
+         (StringSet.is_empty predefined_exceptions)
+         (`List
+           (List.map ~f:(fun s -> `String s) (StringSet.elements predefined_exceptions)))
+    |> add "units" (List.is_empty unit_data) (`List units)
+    |> add "build_info" false (Build_info.to_json build_info))
+
+let info_from_json info =
+  let open Yojson.Basic.Util in
+  let build_info = info |> member "build_info" |> Build_info.from_json in
+  let predefined_exceptions =
+    info
+    |> member "predefined_exceptions"
+    |> to_option to_list
+    |> Option.value ~default:[]
+    |> List.map ~f:to_string
+    |> StringSet.of_list
+  in
+  let unit_data =
+    info
+    |> member "units"
+    |> to_option to_list
+    |> Option.value ~default:[]
+    |> List.map ~f:(fun u ->
+           let unit_info = u |> Unit_info.from_json in
+           let strings =
+             u
+             |> member "strings"
+             |> to_option to_list
+             |> Option.value ~default:[]
+             |> List.map ~f:to_string
+           in
+           let fragments =
+             u
+             |> member "fragments"
+             |> to_option to_string
+             |> Option.map ~f:(fun s -> Marshal.from_string s 0)
+             |> Option.value ~default:[]
+             (*
+                           |> to_option to_assoc
+                           |> Option.value ~default:[]
+                           |> List.map ~f:(fun (nm, e) ->
+                                  ( nm
+                                  , let lex = Parse_js.Lexer.of_string (to_string e) in
+                                    Parse_js.parse_expr lex ))*)
+           in
+           { unit_info; strings; fragments })
+  in
+  build_info, predefined_exceptions, unit_data
+
+let add_info z ?(predefined_exceptions = StringSet.empty) ~build_info ~unit_data () =
+  Zip.add_entry
+    z
+    ~name:"info.json"
+    ~contents:
+      (Yojson.Basic.to_string
+         (info_to_json ~predefined_exceptions ~build_info ~unit_data))
+
+let read_info z =
+  info_from_json (Yojson.Basic.from_string (Zip.read_entry z ~name:"info.json"))
+
+let generate_start_function ~to_link ~out_file =
+  let t1 = Timer.make () in
+  Fs.gen_file out_file
+  @@ fun wasm_file ->
+  let wat_file = Filename.chop_extension out_file ^ ".wat" in
+  (Filename.gen_file wat_file
+  @@ fun ch ->
+  let context = Wa_generate.start () in
+  Wa_generate.add_init_function ~context ~to_link:("prelude" :: to_link);
+  Wa_generate.output
+    ch
+    ~context
+    ~debug:(Parse_bytecode.Debug.create ~include_cmis:false false));
+  Wa_binaryen.optimize
+    ~profile:(Driver.profile 1)
+    ~opt_input_sourcemap:None
+    ~opt_output_sourcemap:None
+    ~opt_sourcemap_url:None
+    ~input_file:wat_file
+    ~output_file:wasm_file;
+  if times () then Format.eprintf "    generate start: %a@." Timer.print t1
 
 let output_js js =
   Code.Var.reset ();
@@ -182,11 +342,14 @@ let report_missing_primitives missing =
     List.iter ~f:(fun nm -> warn "  %s@." nm) missing)
 
 let build_runtime_arguments
+    ?(link_spec = [])
+    ?(separate_compilation = false)
     ~missing_primitives
     ~wasm_file
-    ~generated_js:(strings, fragments) =
+    ~generated_js
+    () =
   let missing_primitives = if Config.Flag.genprim () then missing_primitives else [] in
-  report_missing_primitives missing_primitives;
+  if not separate_compilation then report_missing_primitives missing_primitives;
   let obj l =
     Javascript.EObj
       (List.map
@@ -196,21 +359,31 @@ let build_runtime_arguments
          l)
   in
   let generated_js =
-    let strings =
-      if List.is_empty strings
-      then []
-      else
-        [ ( "strings"
-          , Javascript.EArr
-              (List.map
-                 ~f:(fun s -> Javascript.Element (EStr (Utf8_string.of_string_exn s)))
-                 strings) )
-        ]
-    in
-    let fragments =
-      if List.is_empty fragments then [] else [ "fragments", obj fragments ]
-    in
-    strings @ fragments
+    List.concat
+    @@ List.map
+         ~f:(fun (unit_name, (strings, fragments)) ->
+           let name s =
+             match unit_name with
+             | None -> s
+             | Some nm -> nm ^ "." ^ s
+           in
+           let strings =
+             if List.is_empty strings
+             then []
+             else
+               [ ( name "strings"
+                 , Javascript.EArr
+                     (List.map
+                        ~f:(fun s ->
+                          Javascript.Element (EStr (Utf8_string.of_string_exn s)))
+                        strings) )
+               ]
+           in
+           let fragments =
+             if List.is_empty fragments then [] else [ name "fragments", obj fragments ]
+           in
+           strings @ fragments)
+         generated_js
   in
   let generated_js =
     if not (List.is_empty missing_primitives)
@@ -275,6 +448,283 @@ let build_runtime_arguments
         N
   in
   obj
-    [ "generated", generated_js
+    [ ( "link"
+      , if List.is_empty link_spec
+        then ENum (Javascript.Num.of_int32 (if separate_compilation then 1l else 0l))
+        else
+          EArr
+            (List.map
+               ~f:(fun (m, deps) ->
+                 Javascript.Element
+                   (EArr
+                      [ Element (EStr (Utf8_string.of_string_exn m))
+                      ; Element
+                          (match deps with
+                          | None -> ENum (Javascript.Num.of_int32 0l)
+                          | Some l ->
+                              EArr
+                                (List.map
+                                   ~f:(fun i ->
+                                     Javascript.Element
+                                       (ENum (Javascript.Num.of_int32 (Int32.of_int i))))
+                                   l))
+                      ]))
+               link_spec) )
+    ; "generated", generated_js
     ; "src", EStr (Utf8_string.of_string_exn (Filename.basename wasm_file))
     ]
+
+let link_to_directory ~set_to_link ~files ~enable_source_maps ~dir =
+  let read_interface z ~name =
+    Wasm_binary.read_interface
+      (let ch, pos, len = Zip.get_entry z ~name in
+       Wasm_binary.from_channel ~name ch pos len)
+  in
+  let z = Zip.open_in (fst (List.hd files)) in
+  let runtime_intf = read_interface z ~name:"runtime.wasm" in
+  Zip.extract_file z ~name:"runtime.wasm" ~file:(Filename.concat dir "runtime.wasm");
+  Zip.extract_file z ~name:"prelude.wasm" ~file:(Filename.concat dir "prelude.wasm");
+  Zip.close_in z;
+  let intfs = ref [] in
+  List.iter
+    ~f:(fun (file, (_, units)) ->
+      let z = Zip.open_in file in
+      List.iter
+        ~f:(fun { unit_info; _ } ->
+          let unit_name = StringSet.choose unit_info.provides in
+          if StringSet.mem unit_name set_to_link
+          then (
+            let name = unit_name ^ ".wasm" in
+            intfs := read_interface z ~name :: !intfs;
+            Zip.extract_file z ~name ~file:(Filename.concat dir name);
+            let map = name ^ ".map" in
+            if enable_source_maps && Zip.has_entry z ~name:map
+            then Zip.extract_file z ~name:map ~file:(Filename.concat dir map)))
+        units;
+      Zip.close_in z)
+    files;
+  runtime_intf, List.rev !intfs
+
+(* Remove some unnecessary dependencies *)
+let simplify_unit_info l =
+  let t = Timer.make () in
+  let prev_requires = Hashtbl.create 16 in
+  let res =
+    List.map
+      ~f:(fun (unit_data : unit_data) ->
+        let info = unit_data.unit_info in
+        assert (StringSet.cardinal info.provides = 1);
+        let name = StringSet.choose info.provides in
+        assert (not (StringSet.mem name info.requires));
+        let requires =
+          StringSet.fold
+            (fun dep (requires : StringSet.t) ->
+              match Hashtbl.find prev_requires dep with
+              | exception Not_found -> requires
+              | s -> StringSet.union s requires)
+            info.requires
+            StringSet.empty
+        in
+        let info = { info with requires = StringSet.diff info.requires requires } in
+        Hashtbl.add prev_requires name (StringSet.union info.requires requires);
+        { unit_data with unit_info = info })
+      l
+  in
+  if times () then Format.eprintf "unit info simplification: %a@." Timer.print t;
+  res
+
+let compute_dependencies ~set_to_link ~files =
+  let h = Hashtbl.create 128 in
+  let l = List.concat (List.map ~f:(fun (_, (_, units)) -> units) files) in
+  (*
+  let l = simplify_unit_info l in
+  *)
+  List.filter_map
+    ~f:(fun { unit_info; _ } ->
+      let unit_name = StringSet.choose unit_info.provides in
+      if StringSet.mem unit_name set_to_link
+      then (
+        Hashtbl.add h unit_name (Hashtbl.length h);
+        Some
+          ( unit_name
+          , Some
+              (List.sort ~cmp:compare
+              @@ List.filter_map
+                   ~f:(fun req -> Option.map ~f:(fun i -> i + 2) (Hashtbl.find_opt h req))
+                   (StringSet.elements unit_info.requires)) ))
+      else None)
+    l
+
+let compute_missing_primitives (runtime_intf, intfs) =
+  let provided_primitives = StringSet.of_list runtime_intf.Wasm_binary.exports in
+  StringSet.elements
+  @@ List.fold_left
+       ~f:(fun s { Wasm_binary.imports; _ } ->
+         List.fold_left
+           ~f:(fun s { Wasm_binary.module_; name; _ } ->
+             if String.equal module_ "env" && not (StringSet.mem name provided_primitives)
+             then StringSet.add name s
+             else s)
+           ~init:s
+           imports)
+       ~init:StringSet.empty
+       intfs
+
+let load_information files =
+  match files with
+  | [] -> assert false
+  | runtime :: other_files ->
+      let build_info, predefined_exceptions, _unit_data =
+        Zip.with_open_in runtime read_info
+      in
+      ( predefined_exceptions
+      , (runtime, (build_info, []))
+        :: List.map other_files ~f:(fun file ->
+               let build_info, _predefined_exceptions, unit_data =
+                 Zip.with_open_in file read_info
+               in
+               file, (build_info, unit_data)) )
+
+let link ~output_file ~linkall ~enable_source_maps ~files =
+  let rec loop n =
+    if times () then Format.eprintf "linking@.";
+    let t = Timer.make () in
+    let predefined_exceptions, files = load_information files in
+    (match files with
+    | [] -> assert false
+    | (file, (bi, _)) :: r ->
+        (match Build_info.kind bi with
+        | `Runtime -> ()
+        | _ ->
+            failwith
+              "The first input file should be a runtime built using 'wasm_of_ocaml \
+               build-runtime'.");
+        Build_info.configure bi;
+        ignore
+          (List.fold_left
+             ~init:bi
+             ~f:(fun bi (file', (bi', _)) ->
+               (match Build_info.kind bi' with
+               | `Runtime ->
+                   failwith "The runtime file should be listed first on the command line."
+               | _ -> ());
+               Build_info.merge file bi file' bi')
+             r));
+    if times () then Format.eprintf "    reading information: %a@." Timer.print t;
+    let t1 = Timer.make () in
+    let missing, to_link =
+      List.fold_right
+        files
+        ~init:(StringSet.empty, [])
+        ~f:(fun (_file, (build_info, units)) acc ->
+          let cmo_file =
+            match Build_info.kind build_info with
+            | `Cmo -> true
+            | `Cma | `Exe | `Runtime | `Unknown -> false
+          in
+          List.fold_right units ~init:acc ~f:(fun { unit_info; _ } (requires, to_link) ->
+              if (not (Config.Flag.auto_link ()))
+                 || cmo_file
+                 || linkall
+                 || unit_info.force_link
+                 || not (StringSet.is_empty (StringSet.inter requires unit_info.provides))
+              then
+                ( StringSet.diff
+                    (StringSet.union unit_info.requires requires)
+                    unit_info.provides
+                , StringSet.elements unit_info.provides @ to_link )
+              else requires, to_link))
+    in
+    let set_to_link = StringSet.of_list to_link in
+    let files =
+      if linkall
+      then files
+      else
+        List.filter
+          ~f:(fun (_file, (build_info, units)) ->
+            (match Build_info.kind build_info with
+            | `Cma | `Exe | `Unknown -> false
+            | `Cmo | `Runtime -> true)
+            || List.exists
+                 ~f:(fun { unit_info; _ } ->
+                   StringSet.exists
+                     (fun nm -> StringSet.mem nm set_to_link)
+                     unit_info.provides)
+                 units)
+          files
+    in
+    let missing = StringSet.diff missing predefined_exceptions in
+    if not (StringSet.is_empty missing)
+    then
+      failwith
+        (Printf.sprintf
+           "Could not find compilation unit for %s"
+           (String.concat ~sep:", " (StringSet.elements missing)));
+    if times () then Format.eprintf "    finding what to link: %a@." Timer.print t1;
+    if times () then Format.eprintf "  scan: %a@." Timer.print t;
+    let t = Timer.make () in
+    let interfaces, wasm_file, link_spec =
+      let dir = Filename.chop_extension output_file ^ ".assets" in
+      Fs.gen_file dir
+      @@ fun tmp_dir ->
+      Sys.mkdir tmp_dir 0o777;
+      generate_start_function ~to_link ~out_file:(Filename.concat tmp_dir "start.wasm");
+      ( link_to_directory ~set_to_link ~files ~enable_source_maps ~dir:tmp_dir
+      , dir
+      , let to_link = compute_dependencies ~set_to_link ~files in
+        ("runtime", None) :: ("prelude", None) :: (to_link @ [ "start", None ]) )
+    in
+    let missing_primitives = compute_missing_primitives interfaces in
+    if times () then Format.eprintf "    copy wasm files: %a@." Timer.print t;
+    let t1 = Timer.make () in
+    let js_runtime =
+      match files with
+      | (file, _) :: _ ->
+          Zip.with_open_in file (fun z -> Zip.read_entry z ~name:"runtime.js")
+      | _ -> assert false
+    in
+    let generated_js =
+      List.concat
+      @@ List.map files ~f:(fun (_, (_, units)) ->
+             List.map units ~f:(fun { unit_info; strings; fragments } ->
+                 Some (StringSet.choose unit_info.provides), (strings, fragments)))
+    in
+    let runtime_args =
+      let js =
+        build_runtime_arguments
+          ~link_spec
+          ~separate_compilation:true
+          ~missing_primitives
+          ~wasm_file
+          ~generated_js
+          ()
+      in
+      output_js [ Javascript.Expression_statement js, Javascript.N ]
+    in
+    Fs.gen_file output_file
+    @@ fun tmp_output_file ->
+    Fs.write_file
+      ~name:tmp_output_file
+      ~contents:(trim_semi js_runtime ^ "\n" ^ runtime_args);
+    if times () then Format.eprintf "    build JS runtime: %a@." Timer.print t1;
+    if times () then Format.eprintf "  emit: %a@." Timer.print t;
+    if n > 0 then loop (n - 1)
+  in
+  loop 0
+
+let link ~output_file ~linkall ~enable_source_maps ~files =
+  try link ~output_file ~linkall ~enable_source_maps ~files
+  with Build_info.Incompatible_build_info { key; first = f1, v1; second = f2, v2 } ->
+    let string_of_v = function
+      | None -> "<empty>"
+      | Some v -> v
+    in
+    failwith
+      (Printf.sprintf
+         "Incompatible build info detected while linking.\n - %s: %s=%s\n - %s: %s=%s"
+         f1
+         key
+         (string_of_v v1)
+         f2
+         key
+         (string_of_v v2))

--- a/compiler/lib/wasm/wa_link.mli
+++ b/compiler/lib/wasm/wa_link.mli
@@ -1,0 +1,27 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2017 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+module Wasm_binary : sig
+  type import =
+    { module_ : string
+    ; name : string
+    }
+
+  val read_imports : file:string -> import list
+end

--- a/compiler/lib/wasm/wa_link.mli
+++ b/compiler/lib/wasm/wa_link.mli
@@ -25,3 +25,11 @@ module Wasm_binary : sig
 
   val read_imports : file:string -> import list
 end
+
+val build_runtime_arguments :
+     missing_primitives:string list
+  -> wasm_file:string
+  -> generated_js:string list * (string * Javascript.expression) list
+  -> Javascript.expression
+
+val output_js : Javascript.program -> string

--- a/compiler/lib/wasm/wa_link.mli
+++ b/compiler/lib/wasm/wa_link.mli
@@ -17,6 +17,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+open Stdlib
+
 module Wasm_binary : sig
   type import =
     { module_ : string
@@ -26,10 +28,37 @@ module Wasm_binary : sig
   val read_imports : file:string -> import list
 end
 
+type unit_data =
+  { unit_info : Unit_info.t
+  ; strings : string list
+  ; fragments : (string * Javascript.expression) list
+  }
+
+val add_info :
+     Zip.output
+  -> ?predefined_exceptions:StringSet.t
+  -> build_info:Build_info.t
+  -> unit_data:unit_data list
+  -> unit
+  -> unit
+
 val build_runtime_arguments :
-     missing_primitives:string list
+     ?link_spec:(string * int list option) list
+  -> ?separate_compilation:bool
+  -> missing_primitives:string list
   -> wasm_file:string
-  -> generated_js:string list * (string * Javascript.expression) list
+  -> generated_js:
+       (string option * (string list * (string * Javascript.expression) list)) list
+  -> unit
   -> Javascript.expression
 
+val simplify_unit_info : unit_data list -> unit_data list
+
 val output_js : Javascript.program -> string
+
+val link :
+     output_file:string
+  -> linkall:bool
+  -> enable_source_maps:bool
+  -> files:string list
+  -> unit

--- a/compiler/lib/wasm/wa_tail_call.ml
+++ b/compiler/lib/wasm/wa_tail_call.ml
@@ -11,10 +11,11 @@ let rec rewrite_tail_call ~y i =
   match i with
   | Wa_ast.Location (loc, i') ->
       Option.map ~f:(fun i -> Wa_ast.Location (loc, i)) (rewrite_tail_call ~y i')
-  | LocalSet (x, Call (symb, l)) when x = y -> Some (Return_call (symb, l))
-  | LocalSet (x, Call_indirect (ty, e, l)) when x = y ->
+  | LocalSet (x, Call (symb, l)) when Code.Var.equal x y -> Some (Return_call (symb, l))
+  | LocalSet (x, Call_indirect (ty, e, l)) when Code.Var.equal x y ->
       Some (Return_call_indirect (ty, e, l))
-  | LocalSet (x, Call_ref (ty, e, l)) when x = y -> Some (Return_call_ref (ty, e, l))
+  | LocalSet (x, Call_ref (ty, e, l)) when Code.Var.equal x y ->
+      Some (Return_call_ref (ty, e, l))
   | _ -> None
 
 let rec instruction ~tail i =

--- a/compiler/lib/wasm/wa_target_sig.ml
+++ b/compiler/lib/wasm/wa_target_sig.ml
@@ -181,6 +181,12 @@ module type S = sig
     val int_lsr : expression -> expression -> expression
 
     val int_asr : expression -> expression -> expression
+
+    val block_type : Wa_ast.value_type Wa_code_generation.t
+
+    val dummy_block : expression
+
+    val as_block : expression -> expression
   end
 
   module Constant : sig

--- a/compiler/lib/wasm/wa_target_sig.ml
+++ b/compiler/lib/wasm/wa_target_sig.ml
@@ -295,13 +295,13 @@ module type S = sig
     -> unit Wa_code_generation.t
 
   val post_process_function_body :
-       param_count:int
-    -> locals:Wa_ast.value_type list
+       param_names:Wa_ast.var list
+    -> locals:(Wa_ast.var * Wa_ast.value_type) list
     -> Wa_ast.instruction list
     -> Wa_ast.instruction list
 
   val entry_point :
        context:Wa_code_generation.context
     -> toplevel_fun:Wa_ast.var
-    -> Wa_ast.func_type * unit Wa_code_generation.t
+    -> Wa_ast.func_type * Wa_ast.var list * unit Wa_code_generation.t
 end

--- a/compiler/lib/wasm/wa_target_sig.ml
+++ b/compiler/lib/wasm/wa_target_sig.ml
@@ -307,7 +307,6 @@ module type S = sig
     -> Wa_ast.instruction list
 
   val entry_point :
-       context:Wa_code_generation.context
-    -> toplevel_fun:Wa_ast.var
+       toplevel_fun:Wa_ast.var
     -> Wa_ast.func_type * Wa_ast.var list * unit Wa_code_generation.t
 end

--- a/compiler/lib/wasm/wa_wat_output.ml
+++ b/compiler/lib/wasm/wa_wat_output.ml
@@ -668,9 +668,11 @@ let field ctx st f =
   match f with
   | Function { name; exported_name; typ; param_names; locals; body } ->
       [ funct ctx st name exported_name typ param_names locals body ]
-  | Global { name; typ; init } ->
+  | Global { name; exported_name; typ; init } ->
       [ List
-          (Atom "global" :: symbol st name :: global_type st typ :: expression ctx st init)
+          (Atom "global"
+          :: symbol st name
+          :: (export exported_name @ (global_type st typ :: expression ctx st init)))
       ]
   | Tag { name; typ } ->
       [ List

--- a/compiler/lib/wasm/zip.ml
+++ b/compiler/lib/wasm/zip.ml
@@ -427,8 +427,8 @@ let read_entry z ~name =
 
 let get_entry z ~name =
   let pos = get_pos z ~name in
-  let { pos; len; _ } = read_local_file_header z.ch pos in
-  z.ch, pos, len
+  let { pos; len; crc } = read_local_file_header z.ch pos in
+  z.ch, pos, len, crc
 
 let extract_file z ~name ~file =
   let pos = get_pos z ~name in

--- a/compiler/lib/wasm/zip.ml
+++ b/compiler/lib/wasm/zip.ml
@@ -1,0 +1,451 @@
+let stdlib_close_out = close_out
+
+open Stdlib
+
+module type CRC = sig
+  type t
+
+  val start : t
+
+  val update_from_bytes : bytes -> int -> int -> t -> t
+
+  val update_from_string : string -> int -> int -> t -> t
+
+  val finish : t -> int32
+end
+
+module CRC32 : CRC = struct
+  let compute_table () =
+    let open Int32 in
+    let tbl = Array.make 256 zero in
+    let poly = 0xedb88320l in
+    for i = 0 to 255 do
+      let n = ref (of_int i) in
+      for _ = 0 to 7 do
+        if logand !n one = one
+        then n := logxor (shift_right_logical !n 1) poly
+        else n := shift_right_logical !n 1
+      done;
+      tbl.(i) <- !n
+    done;
+    tbl
+
+  module CRC32 : CRC with type t = int32 = struct
+    type t = int32
+
+    let table = lazy (compute_table ())
+
+    let start = 0xffffffffl
+
+    let update_from_bytes s pos len crc =
+      assert (pos >= 0 && len >= 0 && pos <= Bytes.length s - len);
+      let open Int32 in
+      let tbl = Lazy.force table in
+      let crc = ref crc in
+      for i = pos to pos + len - 1 do
+        crc :=
+          logxor
+            (shift_right_logical !crc 8)
+            (Array.unsafe_get
+               tbl
+               (to_int !crc land 0xff lxor Char.code (Bytes.unsafe_get s i)))
+      done;
+      !crc
+
+    let update_from_string s pos len crc =
+      assert (pos >= 0 && len >= 0 && pos <= String.length s - len);
+      let open Int32 in
+      let tbl = Lazy.force table in
+      let crc = ref crc in
+      for i = pos to pos + len - 1 do
+        crc :=
+          logxor
+            (shift_right_logical !crc 8)
+            (Array.unsafe_get tbl (to_int !crc land 0xff lxor Char.code s.[i]))
+      done;
+      !crc
+
+    let finish crc = Int32.(logxor crc start)
+  end
+
+  module CRC64 : CRC with type t = int = struct
+    type t = int
+
+    let start = (1 lsl 32) - 1
+
+    let next_table tbl tbl' =
+      lazy
+        (let tbl = Lazy.force tbl in
+         let tbl' = Lazy.force tbl' in
+         Array.init 256 ~f:(fun i -> (tbl'.(i) lsr 8) lxor tbl.(tbl'.(i) land 0xFF)))
+
+    let table1 =
+      lazy (Array.map ~f:(fun i -> Int32.to_int i land start) (compute_table ()))
+
+    let table2 = next_table table1 table1
+
+    let table3 = next_table table1 table2
+
+    let table4 = next_table table1 table3
+
+    let table5 = next_table table1 table4
+
+    let table6 = next_table table1 table5
+
+    let table7 = next_table table1 table6
+
+    let table8 = next_table table1 table7
+
+    let update_from_bytes s pos len crc =
+      assert (pos >= 0 && len >= 0 && pos <= Bytes.length s - len);
+      let tbl1 = Lazy.force table1 in
+      let tbl2 = Lazy.force table2 in
+      let tbl3 = Lazy.force table3 in
+      let tbl4 = Lazy.force table4 in
+      let tbl5 = Lazy.force table5 in
+      let tbl6 = Lazy.force table6 in
+      let tbl7 = Lazy.force table7 in
+      let tbl8 = Lazy.force table8 in
+      let crc = ref crc in
+      for i = 0 to (len / 8) - 1 do
+        let pos = pos + (i lsl 3) in
+        crc :=
+          let crc = !crc in
+          Array.unsafe_get tbl8 (crc lxor Char.code (Bytes.unsafe_get s pos) land 0xff)
+          lxor Array.unsafe_get
+                 tbl7
+                 ((crc lsr 8) lxor Char.code (Bytes.unsafe_get s (pos + 1)) land 0xff)
+          lxor (Array.unsafe_get
+                  tbl6
+                  ((crc lsr 16) lxor Char.code (Bytes.unsafe_get s (pos + 2)) land 0xff)
+               lxor Array.unsafe_get
+                      tbl5
+                      ((crc lsr 24) lxor Char.code (Bytes.unsafe_get s (pos + 3))))
+          lxor (Array.unsafe_get tbl4 (Char.code (Bytes.unsafe_get s (pos + 4)))
+               lxor Array.unsafe_get tbl3 (Char.code (Bytes.unsafe_get s (pos + 5)))
+               lxor Array.unsafe_get tbl2 (Char.code (Bytes.unsafe_get s (pos + 6)))
+               lxor Array.unsafe_get tbl1 (Char.code (Bytes.unsafe_get s (pos + 7))))
+      done;
+      for i = pos + (len land -8) to pos + len - 1 do
+        crc :=
+          (!crc lsr 8)
+          lxor Array.unsafe_get tbl1 (!crc land 0xff lxor Char.code (Bytes.unsafe_get s i))
+      done;
+      !crc
+
+    let update_from_string s pos len crc =
+      assert (pos >= 0 && len >= 0 && pos <= String.length s - len);
+      let tbl = Lazy.force table1 in
+      let crc = ref crc in
+      for i = pos to pos + len - 1 do
+        crc := (!crc lsr 8) lxor Array.unsafe_get tbl (!crc land 0xff lxor Char.code s.[i])
+      done;
+      !crc
+
+    let finish crc = Int32.of_int (crc lxor start)
+  end
+
+  module Repr = Sys.Immediate64.Make (Int) (Int32)
+
+  include
+    (val match Repr.repr with
+         | Immediate -> (module CRC64 : CRC)
+         | Non_immediate -> (module CRC32 : CRC)
+        : CRC)
+end
+
+let buffer = lazy (Bytes.create 65536)
+
+let copy in_ch out_ch ?(iter = fun _ _ _ -> ()) len =
+  let buffer = Lazy.force buffer in
+  let buffer_len = Bytes.length buffer in
+  let rec copy rem =
+    if rem > 0
+    then (
+      let n = input in_ch buffer 0 (min buffer_len rem) in
+      if n = 0 then raise End_of_file;
+      iter buffer 0 n;
+      output out_ch buffer 0 n;
+      copy (rem - n))
+  in
+  copy len
+
+type file =
+  { name : string
+  ; pos : int
+  ; len : int
+  ; mutable crc : int32
+  }
+
+type output =
+  { ch : out_channel
+  ; mutable files : file list
+  }
+
+let open_out name = { ch = open_out_bin name; files = [] }
+
+let output_16 ch c =
+  output_byte ch c;
+  output_byte ch (c lsr 8)
+
+let output_32 ch c =
+  output_16 ch c;
+  output_16 ch (c lsr 16)
+
+let output_crc ch crc =
+  output_16 ch (Int32.to_int crc);
+  output_16 ch (Int32.to_int (Int32.shift_right_logical crc 16))
+
+let output_local_file_header ch ?(crc = 0l) { name; len; _ } =
+  output_32 ch 0x04034b50;
+  (* version needed to extract *)
+  output_16 ch 10;
+  (* general purpose but flag *)
+  output_16 ch 0x0;
+  (* compression method *)
+  output_16 ch 0x0;
+  (* time / date *)
+  output_16 ch 0x0;
+  output_16 ch 0x5821;
+  (* CRC *)
+  let crc_pos = pos_out ch in
+  output_crc ch crc;
+  (* compressed / uncompressed size *)
+  output_32 ch len;
+  output_32 ch len;
+  (* file name length *)
+  output_16 ch (String.length name);
+  (* extra field length *)
+  output_16 ch 0;
+  (* file name *)
+  output_string ch name;
+  crc_pos
+
+let add_file z ~name ~file =
+  let ch = open_in_bin file in
+  let pos = pos_out z.ch in
+  let len = in_channel_length ch in
+  let file = { name; pos; len; crc = 0l } in
+  z.files <- file :: z.files;
+  let crc_pos = output_local_file_header z.ch file in
+  let crc = ref CRC32.start in
+  copy ch z.ch ~iter:(fun b pos len -> crc := CRC32.update_from_bytes b pos len !crc) len;
+  let crc = CRC32.finish !crc in
+  file.crc <- crc;
+  let pos = pos_out z.ch in
+  seek_out z.ch crc_pos;
+  output_crc z.ch crc;
+  seek_out z.ch pos
+
+let add_entry z ~name ~contents =
+  let pos = pos_out z.ch in
+  let len = String.length contents in
+  let crc = CRC32.start |> CRC32.update_from_string contents 0 len |> CRC32.finish in
+  let file = { name; pos; len; crc } in
+  z.files <- file :: z.files;
+  let _crc_pos = output_local_file_header z.ch ~crc file in
+  output_string z.ch contents
+
+let output_file_header ch { name; pos; len; crc } =
+  output_32 ch 0x02014b50;
+  (* versions: made by / needed to extract *)
+  output_16 ch 10;
+  output_16 ch 10;
+  (* general purpose but flag *)
+  output_16 ch 0x0;
+  (* compression method *)
+  output_16 ch 0x0;
+  (* time / date *)
+  output_16 ch 0x0;
+  output_16 ch 0x5821;
+  (* CRC *)
+  output_crc ch crc;
+  (* compressed / uncompressed size *)
+  output_32 ch len;
+  output_32 ch len;
+  (* file name length *)
+  output_16 ch (String.length name);
+  (* extra field length *)
+  output_16 ch 0;
+  (* file comment length *)
+  output_16 ch 0;
+  (* disk number start *)
+  output_16 ch 0;
+  (* file attributes *)
+  output_16 ch 0;
+  output_32 ch 0;
+  (* relative offset of local header *)
+  output_32 ch pos;
+  (* file name *)
+  output_string ch name
+
+let output_end_of_directory z pos len =
+  let ch = z.ch in
+  output_32 ch 0x06054b50;
+  (* disk numbers *)
+  output_16 ch 0;
+  output_16 ch 0;
+  (* number of entries *)
+  let n = List.length z.files in
+  output_16 ch n;
+  output_16 ch n;
+  (* size of the central directory *)
+  output_32 ch len;
+  (* offset of the central directory *)
+  output_32 ch pos;
+  (* comment length *)
+  output_16 ch 0
+
+let output_directory z =
+  let pos = pos_out z.ch in
+  List.iter ~f:(output_file_header z.ch) (List.rev z.files);
+  let pos' = pos_out z.ch in
+  output_end_of_directory z pos (pos' - pos)
+
+let close_out z =
+  output_directory z;
+  close_out z.ch
+
+(****)
+
+type entry =
+  { pos : int
+  ; len : int
+  ; crc : int32
+  }
+
+let input_16 ch =
+  let c = input_byte ch in
+  c lor (input_byte ch lsl 8)
+
+let input_32 ch =
+  let c = input_16 ch in
+  c lor (input_16 ch lsl 16)
+
+let input_32' ch =
+  let c = input_16 ch in
+  Int32.(logor (of_int c) (shift_left (of_int (input_16 ch)) 16))
+
+let read_local_file_header ch pos =
+  let pos = pos + 14 in
+  seek_in ch pos;
+  let crc = input_32' ch in
+  let _ = input_32 ch in
+  let len = input_32 ch in
+  let name_len = input_16 ch in
+  let extra_len = input_16 ch in
+  { pos = pos + 16 + name_len + extra_len; len; crc }
+
+let read_file_header ch =
+  let signature = input_32' ch in
+  if not (Int32.equal signature 0x02014b50l) then failwith "bad signature";
+  (* versions: made by / needed to extract *)
+  ignore (input_16 ch);
+  let v = input_16 ch in
+  if v > 10 then failwith "unsupported file format";
+  (* general purpose but flag *)
+  ignore (input_16 ch);
+  (* compression method *)
+  ignore (input_16 ch);
+  (* time / date *)
+  ignore (input_32 ch);
+  (* CRC *)
+  ignore (input_32' ch);
+  (* compressed / uncompressed size *)
+  ignore (input_32 ch);
+  ignore (input_32 ch);
+  (* file name length *)
+  let name_len = input_16 ch in
+  (* extra field length *)
+  let extra_len = input_16 ch in
+  (* file comment length *)
+  let comment_len = input_16 ch in
+  (* disk number start *)
+  ignore (input_16 ch);
+  (* file attributes *)
+  ignore (input_16 ch);
+  ignore (input_32 ch);
+  (* relative offset of local header *)
+  let pos = input_32 ch in
+  (* file name *)
+  let name = really_input_string ch name_len in
+  ignore (really_input_string ch extra_len);
+  ignore (really_input_string ch comment_len);
+  name, pos
+
+type input =
+  { ch : in_channel
+  ; files : int StringMap.t
+  }
+
+let open_in name =
+  let ch = open_in_bin name in
+  let len = in_channel_length ch in
+  let find_directory_end offset =
+    seek_in ch (len - 22 - offset);
+    let c = ref 0l in
+    let p = ref (-1) in
+    for i = 0 to offset + 3 do
+      (c := Int32.(add (shift_left !c 8) (of_int (input_byte ch))));
+      if Int32.equal !c 0x504b0506l then p := 22 + 3 + offset - i
+    done;
+    !p
+  in
+  let p = find_directory_end 0 in
+  let p = if p = -1 then find_directory_end 65535 else p in
+  if p = -1 then failwith "not a ZIP file";
+  seek_in ch (len - p + 10);
+  (* number of entries *)
+  let n = input_16 ch in
+  (* size of the directory *)
+  ignore (input_32 ch);
+  (* offset of the directory *)
+  let offset = input_32 ch in
+  seek_in ch offset;
+  let m = ref StringMap.empty in
+  for _ = 0 to n - 1 do
+    let name, entry = read_file_header ch in
+    m := StringMap.add name entry !m
+  done;
+  { ch; files = !m }
+
+let with_open_in name f =
+  let z = open_in name in
+  Fun.protect ~finally:(fun () -> close_in_noerr z.ch) (fun () -> f z)
+
+let get_pos z ~name =
+  try StringMap.find name z.files
+  with Not_found -> failwith (Printf.sprintf "File %s not found in archive" name)
+
+let has_entry z ~name = StringMap.mem name z.files
+
+let read_entry z ~name =
+  let pos = get_pos z ~name in
+  let { pos; len; _ } = read_local_file_header z.ch pos in
+  seek_in z.ch pos;
+  really_input_string z.ch len
+
+let get_entry z ~name =
+  let pos = get_pos z ~name in
+  let { pos; len; _ } = read_local_file_header z.ch pos in
+  z.ch, pos, len
+
+let extract_file z ~name ~file =
+  let pos = get_pos z ~name in
+  let { pos; len; _ } = read_local_file_header z.ch pos in
+  seek_in z.ch pos;
+  let ch = open_out_bin file in
+  copy z.ch ch len;
+  stdlib_close_out ch
+
+let close_in z = close_in z.ch
+
+let copy_file z (z' : output) ~src_name ~dst_name =
+  let pos = StringMap.find src_name z.files in
+  let { pos; len; crc } = read_local_file_header z.ch pos in
+  seek_in z.ch pos;
+  let pos' = pos_out z'.ch in
+  let file = { name = dst_name; pos = pos'; len; crc } in
+  z'.files <- file :: z'.files;
+  let _ = output_local_file_header z'.ch ~crc file in
+  copy z.ch z'.ch len

--- a/compiler/lib/wasm/zip.mli
+++ b/compiler/lib/wasm/zip.mli
@@ -18,7 +18,8 @@ val has_entry : input -> name:string -> bool
 
 val read_entry : input -> name:string -> string
 
-val get_entry : input -> name:string -> in_channel * int (* pos *) * int (* len *)
+val get_entry :
+  input -> name:string -> in_channel * int (* pos *) * int (* len *) * int32 (* crc *)
 
 val extract_file : input -> name:string -> file:string -> unit
 

--- a/compiler/lib/wasm/zip.mli
+++ b/compiler/lib/wasm/zip.mli
@@ -1,0 +1,27 @@
+type output
+
+val open_out : string -> output
+
+val add_entry : output -> name:string -> contents:string -> unit
+
+val add_file : output -> name:string -> file:string -> unit
+
+val close_out : output -> unit
+
+type input
+
+val open_in : string -> input
+
+val with_open_in : string -> (input -> 'a) -> 'a
+
+val has_entry : input -> name:string -> bool
+
+val read_entry : input -> name:string -> string
+
+val get_entry : input -> name:string -> in_channel * int (* pos *) * int (* len *)
+
+val extract_file : input -> name:string -> file:string -> unit
+
+val copy_file : input -> output -> src_name:string -> dst_name:string -> unit
+
+val close_in : input -> unit

--- a/dune
+++ b/dune
@@ -12,10 +12,12 @@
  (wasm
   (binaries (tools/node_wrapper.sh as node))
   (js_of_ocaml
+   (compilation_mode separate)
    (targets wasm)))
  (wasm-effects
   (binaries (tools/node_wrapper.sh as node))
   (js_of_ocaml
+   (compilation_mode separate)
    (flags
     (:standard --enable effects))
    (targets wasm)))

--- a/tools/ci_setup.ml
+++ b/tools/ci_setup.ml
@@ -18,7 +18,7 @@ let omitted_others = StringSet.of_list [ "cohttp-async"; "cohttp"; "uri"; "uri-s
 
 let omitted_js = StringSet.of_list [ "sexplib0" ]
 
-let do_not_pin = StringSet.of_list [ "wasocaml"; "wasm_of_ocaml" ]
+let do_not_pin = StringSet.of_list [ "wasocaml"; "wasm_of_ocaml"; "dune" ]
 
 let do_pin = StringSet.of_list [ "base"; "ppx_expect"; "ppx_inline_test"; "time_now" ]
 


### PR DESCRIPTION
The compilation process is basically the same as with Js_of_ocaml. One needs to build a standalone runtime:
```
wasm_of_ocaml build-runtime foo.js bar.wat ... -o runtime.wasma
```
Then, one compiles .cma and .cmo files.
```
wasm_of_ocaml --pretty --source-map-inline base.cma -o base.wasma
wasm_of_ocaml --pretty --source-map-inline foo.cmo -o base.wasmo
```
Finally, one links all these files.
```
wasm_of_ocaml link --source-map-inline runtime.wasma base.wasma ... foo.wasmo -o program.js
```
Besides a JavaScript file `program.js`, this generates a `program.assets` directory containing Wasm binary files and source map files.

At the moment, one Wasm module is produced for each OCaml module, but the V8 Wasm engine is somewhat struggling with so many modules, so I should probably reconsider this.

Another improvement would be to be able to compile each cmo files in a library separately before linking them together, as suggested by @hhugo in https://github.com/ocaml/dune/pull/7389.