### PR TITLE
Improved separate compilation

### DIFF
--- a/.github/workflows/build-wasm_of_ocaml.yml
+++ b/.github/workflows/build-wasm_of_ocaml.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Pin dune
         run: |
-          opam pin add -n dune.3.17 https://github.com/ocaml-wasm/dune.git#wasm_of_ocaml
+          opam pin add -n dune.3.17 https://github.com/ocaml-wasm/dune.git#wasm_of_ocaml-incremental
 
       - name: Pin wasm_of_ocaml
         working-directory: ./wasm_of_ocaml

--- a/compiler/bin-wasm_of_ocaml/link.ml
+++ b/compiler/bin-wasm_of_ocaml/link.ml
@@ -25,6 +25,7 @@ type t =
   ; files : string list
   ; output_file : string
   ; linkall : bool
+  ; mklib : bool
   ; enable_source_maps : bool
   }
 
@@ -53,9 +54,16 @@ let options =
     let doc = "Link all compilation units." in
     Arg.(value & flag & info [ "linkall" ] ~doc)
   in
-  let build_t common no_sourcemap sourcemap output_file files linkall =
+  let mklib =
+    let doc =
+      "Build a library (.wasma file) with the .wasmo files given on the command line. \
+       Similar to ocamlc -a."
+    in
+    Arg.(value & flag & info [ "a" ] ~doc)
+  in
+  let build_t common no_sourcemap sourcemap output_file files linkall mklib =
     let enable_source_maps = (not no_sourcemap) && sourcemap in
-    `Ok { common; output_file; files; linkall; enable_source_maps }
+    `Ok { common; output_file; files; linkall; mklib; enable_source_maps }
   in
   let t =
     Term.(
@@ -65,13 +73,14 @@ let options =
       $ sourcemap
       $ output_file
       $ files
-      $ linkall)
+      $ linkall
+      $ mklib)
   in
   Term.ret t
 
-let f { common; output_file; files; linkall; enable_source_maps } =
+let f { common; output_file; files; linkall; enable_source_maps; mklib } =
   Jsoo_cmdline.Arg.eval common;
-  Wa_link.link ~output_file ~linkall ~enable_source_maps ~files
+  Wa_link.link ~output_file ~linkall ~mklib ~enable_source_maps ~files
 
 let info =
   Info.make

--- a/compiler/lib/wasm/wa_generate.ml
+++ b/compiler/lib/wasm/wa_generate.ml
@@ -1269,3 +1269,8 @@ let output ch ~context ~debug =
       let module G = Generate (Wa_gc_target) in
       let fields = G.output ~context in
       Wa_wat_output.f ~debug ch fields
+
+let wasm_output ch ~context =
+  let module G = Generate (Wa_gc_target) in
+  let fields = G.output ~context in
+  Wa_wasm_output.f ch fields

--- a/compiler/lib/wasm/wa_generate.mli
+++ b/compiler/lib/wasm/wa_generate.mli
@@ -38,3 +38,5 @@ val output :
   -> context:Wa_code_generation.context
   -> debug:Parse_bytecode.Debug.t
   -> unit
+
+val wasm_output : out_channel -> context:Wa_code_generation.context -> unit

--- a/compiler/lib/wasm/wa_link.ml
+++ b/compiler/lib/wasm/wa_link.ml
@@ -570,11 +570,44 @@ let build_runtime_arguments
     ; "src", EStr (Utf8_string.of_string_exn (Filename.basename wasm_dir))
     ]
 
-let link_to_directory ~set_to_link ~files ~enable_source_maps ~dir =
-  let process_file z ~name =
+let source_name i j file =
+  let prefix =
+    match i, j with
+    | None, None -> "src-"
+    | Some i, None -> Printf.sprintf "src-%d-" i
+    | None, Some j -> Printf.sprintf "src-%d-" j
+    | Some i, Some j -> Printf.sprintf "src-%d.%d-" i j
+  in
+  prefix ^ Filename.basename file ^ ".json"
+
+let extract_source_map ~dir ~name z =
+  if Zip.has_entry z ~name:"source_map.map"
+  then (
+    let sm = Wa_source_map.parse (Zip.read_entry z ~name:"source_map.map") in
+    let sm =
+      let rewrite_path path =
+        if Filename.is_relative path
+        then path
+        else
+          match Build_path_prefix_map.get_build_path_prefix_map () with
+          | Some map -> Build_path_prefix_map.rewrite map path
+          | None -> path
+      in
+      Wa_source_map.insert_source_contents ~rewrite_path sm (fun i j file ->
+          let name = source_name i j file in
+          if Zip.has_entry z ~name then Some (Zip.read_entry z ~name) else None)
+    in
+    let map_name = name ^ ".wasm.map" in
+    Wa_source_map.write (Filename.concat dir map_name) sm;
+    Wasm_binary.append_source_map_section
+      ~file:(Filename.concat dir (name ^ ".wasm"))
+      ~url:map_name)
+
+let link_to_directory ~files_to_link ~files ~enable_source_maps ~dir =
+  let process_file z ~name ~name' =
     let ch, pos, len, crc = Zip.get_entry z ~name:(name ^ ".wasm") in
     let intf = Wasm_binary.read_interface (Wasm_binary.from_channel ~name ch pos len) in
-    let name' = Printf.sprintf "%s-%08lx" name crc in
+    let name' = Printf.sprintf "%s-%08lx" name' crc in
     Zip.extract_file
       z
       ~name:(name ^ ".wasm")
@@ -582,50 +615,48 @@ let link_to_directory ~set_to_link ~files ~enable_source_maps ~dir =
     name', intf
   in
   let z = Zip.open_in (fst (List.hd files)) in
-  let runtime, runtime_intf = process_file z ~name:"runtime" in
-  let prelude, _ = process_file z ~name:"prelude" in
+  let runtime, runtime_intf = process_file z ~name:"runtime" ~name':"runtime" in
+  let prelude, _ = process_file z ~name:"prelude" ~name':"prelude" in
   Zip.close_in z;
   let lst =
-    List.map
-      ~f:(fun (file, (_, units)) ->
-        let z = Zip.open_in file in
-        let res =
-          List.map
-            ~f:(fun { unit_name; unit_info; _ } ->
-              if StringSet.mem unit_name set_to_link
-              then (
-                let name = unit_name ^ ".wasm" in
-                let res = process_file z ~name:unit_name in
-                let map = name ^ ".map" in
-                if enable_source_maps && Zip.has_entry z ~name:map
-                then Zip.extract_file z ~name:map ~file:(Filename.concat dir map);
-                Some res)
-              else None)
-            units
-        in
-        Zip.close_in z;
-        List.filter_map ~f:(fun x -> x) res)
-      files
-    |> List.flatten
+    List.tl files
+    |> List.map ~f:(fun (file, _) ->
+           if StringSet.mem file files_to_link
+           then (
+             let z = Zip.open_in file in
+             let name' = file |> Filename.basename |> Filename.remove_extension in
+             let ((name', _) as res) = process_file z ~name:"code" ~name' in
+             if enable_source_maps then extract_source_map ~dir ~name:name' z;
+             Zip.close_in z;
+             Some res)
+           else None)
+    |> List.filter_map ~f:(fun x -> x)
   in
   runtime :: prelude :: List.map ~f:fst lst, (runtime_intf, List.map ~f:snd lst)
 
-let compute_dependencies ~set_to_link ~files =
+let compute_dependencies ~files_to_link ~files =
   let h = Hashtbl.create 128 in
-  let l = List.concat (List.map ~f:(fun (_, (_, units)) -> units) files) in
+  let i = ref 2 in
   List.filter_map
-    ~f:(fun { unit_name; unit_info; _ } ->
-      if StringSet.mem unit_name set_to_link
+    ~f:(fun (file, (_, units)) ->
+      if StringSet.mem file files_to_link
       then (
-        Hashtbl.add h unit_name (Hashtbl.length h);
-        Some
-          (Some
-             (List.sort ~cmp:compare
-             @@ List.filter_map
-                  ~f:(fun req -> Option.map ~f:(fun i -> i + 2) (Hashtbl.find_opt h req))
-                  (StringSet.elements unit_info.requires))))
+        let s =
+          List.fold_left
+            ~f:(fun s { unit_info; _ } ->
+              StringSet.fold
+                (fun unit_name s ->
+                  try IntSet.add (Hashtbl.find h unit_name) s with Not_found -> s)
+                unit_info.requires
+                s)
+            ~init:IntSet.empty
+            units
+        in
+        List.iter ~f:(fun { unit_name; _ } -> Hashtbl.add h unit_name !i) units;
+        incr i;
+        Some (Some (IntSet.elements s)))
       else None)
-    l
+    (List.tl files)
 
 let compute_missing_primitives (runtime_intf, intfs) =
   let provided_primitives = StringSet.of_list runtime_intf.Wasm_binary.exports in
@@ -683,7 +714,33 @@ let link ~output_file ~linkall ~enable_source_maps ~files =
            r));
   if times () then Format.eprintf "    reading information: %a@." Timer.print t;
   let t1 = Timer.make () in
-  let missing, to_link =
+  let missing, files_to_link =
+    List.fold_right
+      files
+      ~init:(StringSet.empty, StringSet.empty)
+      ~f:(fun (file, (build_info, units)) (requires, files_to_link) ->
+        let cmo_file =
+          match Build_info.kind build_info with
+          | `Cmo -> true
+          | `Cma | `Exe | `Runtime | `Unknown -> false
+        in
+        if (not (Config.Flag.auto_link ()))
+           || cmo_file
+           || linkall
+           || List.exists ~f:(fun { unit_info; _ } -> unit_info.force_link) units
+           || List.exists
+                ~f:(fun { unit_info; _ } ->
+                  not (StringSet.is_empty (StringSet.inter requires unit_info.provides)))
+                units
+        then
+          ( List.fold_right units ~init:requires ~f:(fun { unit_info; _ } requires ->
+                StringSet.diff
+                  (StringSet.union unit_info.requires requires)
+                  unit_info.provides)
+          , StringSet.add file files_to_link )
+        else requires, files_to_link)
+  in
+  let _, to_link =
     List.fold_right
       files
       ~init:(StringSet.empty, [])
@@ -708,21 +765,6 @@ let link ~output_file ~linkall ~enable_source_maps ~files =
                   unit_info.provides
               , unit_name :: to_link )
             else requires, to_link))
-  in
-  let set_to_link = StringSet.of_list to_link in
-  let files =
-    if linkall
-    then files
-    else
-      List.filter
-        ~f:(fun (_file, (build_info, units)) ->
-          (match Build_info.kind build_info with
-          | `Cma | `Exe | `Unknown -> false
-          | `Cmo | `Runtime -> true)
-          || List.exists
-               ~f:(fun { unit_name; _ } -> StringSet.mem unit_name set_to_link)
-               units)
-        files
   in
   let missing = StringSet.diff missing predefined_exceptions in
   if not (StringSet.is_empty missing)
@@ -750,11 +792,11 @@ let link ~output_file ~linkall ~enable_source_maps ~files =
       ~to_link
       ~out_file:(Filename.concat tmp_dir (start_module ^ ".wasm"));
     let module_names, interfaces =
-      link_to_directory ~set_to_link ~files ~enable_source_maps ~dir:tmp_dir
+      link_to_directory ~files_to_link ~files ~enable_source_maps ~dir:tmp_dir
     in
     ( interfaces
     , dir
-    , let to_link = compute_dependencies ~set_to_link ~files in
+    , let to_link = compute_dependencies ~files_to_link ~files in
       List.combine module_names (None :: None :: to_link) @ [ start_module, None ] )
   in
   let missing_primitives = compute_missing_primitives interfaces in

--- a/compiler/lib/wasm/wa_link.ml
+++ b/compiler/lib/wasm/wa_link.ml
@@ -385,23 +385,11 @@ let read_info z = info_from_sexp (Sexp.from_string (Zip.read_entry z ~name:"info
 
 let generate_start_function ~to_link ~out_file =
   let t1 = Timer.make () in
-  Fs.gen_file out_file
-  @@ fun wasm_file ->
-  let wat_file = Filename.chop_extension out_file ^ ".wat" in
-  (Filename.gen_file wat_file
+  Filename.gen_file out_file
   @@ fun ch ->
   let context = Wa_generate.start () in
   Wa_generate.add_init_function ~context ~to_link:("prelude" :: to_link);
-  Wa_generate.output
-    ch
-    ~context
-    ~debug:(Parse_bytecode.Debug.create ~include_cmis:false false));
-  Wa_binaryen.optimize
-    ~profile:(Driver.profile 1)
-    ~opt_input_sourcemap:None
-    ~opt_output_sourcemap:None
-    ~input_file:wat_file
-    ~output_file:wasm_file;
+  Wa_generate.wasm_output ch ~context;
   if times () then Format.eprintf "    generate start: %a@." Timer.print t1
 
 let output_js js =

--- a/compiler/lib/wasm/wa_link.mli
+++ b/compiler/lib/wasm/wa_link.mli
@@ -62,3 +62,5 @@ val link :
   -> enable_source_maps:bool
   -> files:string list
   -> unit
+
+val source_name : int option -> int option -> string -> string

--- a/compiler/lib/wasm/wa_link.mli
+++ b/compiler/lib/wasm/wa_link.mli
@@ -59,6 +59,7 @@ val output_js : Javascript.program -> string
 val link :
      output_file:string
   -> linkall:bool
+  -> mklib:bool
   -> enable_source_maps:bool
   -> files:string list
   -> unit

--- a/compiler/lib/wasm/wa_source_map.ml
+++ b/compiler/lib/wasm/wa_source_map.ml
@@ -1,0 +1,244 @@
+open Stdlib
+
+type resize_data =
+  { mutable i : int
+  ; mutable pos : int array
+  ; mutable delta : int array
+  }
+
+type t = Yojson.Raw.t
+
+type u =
+  { mappings : string
+  ; mutable pos : int
+  }
+
+module Vlq = struct
+  let code = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+
+  let code_rev =
+    let a = Array.make 255 (-1) in
+    for i = 0 to String.length code - 1 do
+      a.(Char.code code.[i]) <- i
+    done;
+    a
+
+  let vlq_base_shift = 5
+
+  let vlq_base = 1 lsl vlq_base_shift
+
+  let vlq_base_mask = vlq_base - 1
+
+  let vlq_continuation_bit = vlq_base
+
+  let rec decode' src s pos offset i =
+    let digit = Array.unsafe_get code_rev (Char.code s.[pos]) in
+    if digit = -1 then invalid_arg "Vql64.decode'";
+    let i = i + ((digit land vlq_base_mask) lsl offset) in
+    if digit >= vlq_continuation_bit
+    then decode' src s (pos + 1) (offset + vlq_base_shift) i
+    else (
+      src.pos <- pos + 1;
+      i)
+
+  let fromVLQSigned v =
+    let is_neg = v land 1 = 1 in
+    let shift = v lsr 1 in
+    if is_neg then -shift else shift
+
+  let toVLQSigned v = if v < 0 then (-v lsl 1) + 1 else v lsl 1
+
+  let decode src = fromVLQSigned (decode' src src.mappings src.pos 0 0)
+
+  let rec encode' buf i =
+    let digit = i land vlq_base_mask in
+    let i = i lsr vlq_base_shift in
+    if i = 0
+    then Buffer.add_char buf (String.unsafe_get code digit)
+    else (
+      Buffer.add_char buf (String.unsafe_get code (digit lor vlq_continuation_bit));
+      encode' buf i)
+
+  let encode buf i = encode' buf (toVLQSigned i)
+end
+
+let rec next' src mappings pos =
+  match mappings.[pos] with
+  | '"' ->
+      src.pos <- pos + 1;
+      false
+  | ',' ->
+      src.pos <- pos + 1;
+      true
+  | _ -> next' src mappings (pos + 1)
+
+let next src = next' src src.mappings src.pos
+
+let flush buf src start pos =
+  if start < pos then Buffer.add_substring buf src.mappings start (pos - start)
+
+let rec resize_rec buf start src resize_data i col0 delta0 col =
+  let pos = src.pos in
+  let delta = Vlq.decode src in
+  let col = col + delta in
+  if col < col0
+  then
+    if next src
+    then resize_rec buf start src resize_data i col0 delta0 col
+    else flush buf src start (String.length src.mappings)
+  else
+    let delta = delta + delta0 in
+    adjust buf start src resize_data i col delta pos
+
+and adjust buf start src (resize_data : resize_data) i col delta pos =
+  assert (delta > 0);
+  if i < resize_data.i
+  then
+    let col0 = resize_data.pos.(i) in
+    let delta0 = resize_data.delta.(i) in
+    if col < col0
+    then (
+      flush buf src start pos;
+      Vlq.encode buf delta;
+      let start = src.pos in
+      if next src
+      then resize_rec buf start src resize_data (i + 1) col0 delta0 col
+      else flush buf src start (String.length src.mappings))
+    else
+      let delta = delta + delta0 in
+      adjust buf start src resize_data (i + 1) col delta pos
+  else (
+    flush buf src start pos;
+    Vlq.encode buf delta;
+    let start = src.pos in
+    flush buf src start (String.length src.mappings))
+
+let resize_mappings (resize_data : resize_data) mappings =
+  if String.equal mappings "\"\"" || resize_data.i = 0
+  then mappings
+  else
+    let col0 = resize_data.pos.(0) in
+    let delta0 = resize_data.delta.(0) in
+    let buf = Buffer.create (String.length mappings) in
+    resize_rec buf 0 { mappings; pos = 1 } resize_data 1 col0 delta0 0;
+    Buffer.contents buf
+
+let to_raw_string v =
+  match v with
+  | `Stringlit s -> s
+  | _ -> assert false
+
+let replace_member assoc m v =
+  `Assoc ((m, v) :: List.remove_assoc m (Yojson.Raw.Util.to_assoc assoc))
+
+let resize resize_data sm =
+  let open Yojson.Raw.Util in
+  let mappings = to_raw_string (member "mappings" sm) in
+  let mappings = resize_mappings resize_data mappings in
+  replace_member sm "mappings" (`Stringlit mappings)
+
+let is_empty sm =
+  let open Yojson.Raw.Util in
+  match member "mappings" sm with
+  | `Stringlit "\"\"" -> true
+  | _ -> false
+
+let concatenate l =
+  `Assoc
+    [ "version", `Intlit "3"
+    ; ( "sections"
+      , `List
+          (List.map
+             ~f:(fun (ofs, sm) ->
+               `Assoc
+                 [ ( "offset"
+                   , `Assoc [ "line", `Intlit "0"; "column", `Intlit (string_of_int ofs) ]
+                   )
+                 ; "map", sm
+                 ])
+             l) )
+    ]
+
+let parse ?tmp_buf s = Yojson.Raw.from_string ?buf:tmp_buf s
+
+let load ?tmp_buf name = parse ?tmp_buf (Fs.read_file name)
+
+let write name sm = Yojson.Raw.to_file name sm
+
+let string_from_raw_string s = Yojson.Basic.Util.to_string (Yojson.Basic.from_string s)
+
+let raw_string_from_string s = Yojson.Basic.to_string (`String s)
+
+let iter_sources' sm i f =
+  let open Yojson.Raw.Util in
+  let l = sm |> member "sources" |> to_option to_list |> Option.value ~default:[] in
+  let single = List.length l = 1 in
+  List.iteri
+    ~f:(fun j nm ->
+      f i (if single then None else Some j) (string_from_raw_string (to_raw_string nm)))
+    l
+
+let iter_sources sm f =
+  let open Yojson.Raw.Util in
+  match to_option to_list (member "sections" sm) with
+  | None -> iter_sources' sm None f
+  | Some l ->
+      let single_map = List.length l = 1 in
+      List.iteri
+        ~f:(fun i entry ->
+          iter_sources' (member "map" entry) (if single_map then None else Some i) f)
+        l
+
+let insert_source_contents' ~rewrite_path sm i f =
+  let rewrite_path path =
+    raw_string_from_string (rewrite_path (string_from_raw_string path))
+  in
+  let open Yojson.Raw.Util in
+  let l = sm |> member "sources" |> to_option to_list |> Option.value ~default:[] in
+  let single = List.length l = 1 in
+  let contents =
+    List.mapi
+      ~f:(fun j nm ->
+        match
+          f
+            i
+            (if single then None else Some j)
+            (string_from_raw_string (to_raw_string nm))
+        with
+        | Some c -> `Stringlit c
+        | None -> `Null)
+      l
+  in
+  let sm = replace_member sm "sourcesContent" (`List contents) in
+  let sm =
+    replace_member
+      sm
+      "sources"
+      (match member "sources" sm with
+      | `Null -> `Null
+      | `List l ->
+          `List (List.map ~f:(fun s -> `Stringlit (rewrite_path (to_raw_string s))) l)
+      | _ -> assert false)
+  in
+  sm
+
+let insert_source_contents ~rewrite_path sm f =
+  let open Yojson.Raw.Util in
+  match to_option to_list (member "sections" sm) with
+  | None -> insert_source_contents' ~rewrite_path sm None f
+  | Some l ->
+      let single_map = List.length l = 1 in
+      let sections =
+        List.mapi
+          ~f:(fun i entry ->
+            replace_member
+              entry
+              "map"
+              (insert_source_contents'
+                 ~rewrite_path
+                 (member "map" entry)
+                 (if single_map then None else Some i)
+                 f))
+          l
+      in
+      replace_member sm "sections" (`List sections)

--- a/compiler/lib/wasm/wa_source_map.mli
+++ b/compiler/lib/wasm/wa_source_map.mli
@@ -1,0 +1,27 @@
+type t
+
+val load : ?tmp_buf:Buffer.t -> string -> t
+
+val parse : ?tmp_buf:Buffer.t -> string -> t
+
+val write : string -> t -> unit
+
+val is_empty : t -> bool
+
+type resize_data =
+  { mutable i : int
+  ; mutable pos : int array
+  ; mutable delta : int array
+  }
+
+val resize : resize_data -> t -> t
+
+val concatenate : (int * t) list -> t
+
+val iter_sources : t -> (int option -> int option -> string -> unit) -> unit
+
+val insert_source_contents :
+     rewrite_path:(string -> string)
+  -> t
+  -> (int option -> int option -> string -> string option)
+  -> t

--- a/compiler/lib/wasm/wa_wasm_link.ml
+++ b/compiler/lib/wasm/wa_wasm_link.ml
@@ -1,0 +1,2443 @@
+open Stdlib
+
+type heaptype =
+  | Func
+  | Nofunc
+  | Extern
+  | Noextern
+  | Any
+  | Eq
+  | I31
+  | Struct
+  | Array
+  | None_
+  | Type of int
+
+type reftype =
+  { nullable : bool
+  ; typ : heaptype
+  }
+
+type valtype =
+  | I32
+  | I64
+  | F32
+  | F64
+  | V128
+  | Ref of reftype
+
+type packedtype =
+  | I8
+  | I16
+
+type storagetype =
+  | Val of valtype
+  | Packed of packedtype
+
+type 'ty mut =
+  { mut : bool
+  ; typ : 'ty
+  }
+
+type fieldtype = storagetype mut
+
+type comptype =
+  | Func of
+      { params : valtype array
+      ; results : valtype array
+      }
+  | Struct of fieldtype array
+  | Array of fieldtype
+
+type subtype =
+  { final : bool
+  ; supertype : int option
+  ; typ : comptype
+  }
+
+type rectype = subtype array
+
+type limits =
+  { min : int
+  ; max : int option
+  ; shared : bool
+  ; index_type : [ `I32 | `I64 ]
+  }
+
+type tabletype =
+  { limits : limits
+  ; typ : reftype
+  }
+
+type importdesc =
+  | Func of int
+  | Table of tabletype
+  | Mem of limits
+  | Global of valtype mut
+  | Tag of int
+
+type import =
+  { module_ : string
+  ; name : string
+  ; desc : importdesc
+  }
+
+type exportable =
+  | Func
+  | Table
+  | Mem
+  | Global
+  | Tag
+
+let rec output_uint ch i =
+  if i < 128
+  then output_byte ch i
+  else (
+    output_byte ch (128 + (i land 127));
+    output_uint ch (i lsr 7))
+
+module Write = struct
+  type st = { mutable type_index_count : int }
+
+  let byte ch b = Buffer.add_char ch (Char.chr b)
+
+  let string ch s = Buffer.add_string ch s
+
+  let rec sint ch i =
+    if i >= -64 && i < 64
+    then byte ch (i land 127)
+    else (
+      byte ch (128 + (i land 127));
+      sint ch (i asr 7))
+
+  let rec uint ch i =
+    if i < 128
+    then byte ch i
+    else (
+      byte ch (128 + (i land 127));
+      uint ch (i lsr 7))
+
+  let vec f ch l =
+    uint ch (Array.length l);
+    Array.iter ~f:(fun x -> f ch x) l
+
+  let name ch name =
+    uint ch (String.length name);
+    string ch name
+
+  let typeidx st idx = if idx < 0 then lnot idx + st.type_index_count else idx
+
+  let heaptype st ch typ =
+    match (typ : heaptype) with
+    | Nofunc -> byte ch 0x73
+    | Noextern -> byte ch 0x72
+    | None_ -> byte ch 0x71
+    | Func -> byte ch 0x70
+    | Extern -> byte ch 0x6F
+    | Any -> byte ch 0x6E
+    | Eq -> byte ch 0x6D
+    | I31 -> byte ch 0x6C
+    | Struct -> byte ch 0x6B
+    | Array -> byte ch 0x6A
+    | Type idx -> sint ch (typeidx st idx)
+
+  let reftype st ch { nullable; typ } =
+    (match nullable, typ with
+    | false, _ -> byte ch 0x64
+    | true, Type _ -> byte ch 0x63
+    | _ -> ());
+    heaptype st ch typ
+
+  let valtype st ch (typ : valtype) =
+    match typ with
+    | I32 -> byte ch 0x7F
+    | I64 -> byte ch 0x7E
+    | F32 -> byte ch 0x7D
+    | F64 -> byte ch 0x7C
+    | V128 -> byte ch 0x7B
+    | Ref typ -> reftype st ch typ
+
+  let mutability ch mut = byte ch (if mut then 0x01 else 0x00)
+
+  let fieldtype st ch { mut; typ } =
+    (match typ with
+    | Val typ -> valtype st ch typ
+    | Packed typ -> (
+        match typ with
+        | I8 -> byte ch 0x78
+        | I16 -> byte ch 0x77));
+    mutability ch mut
+
+  let functype st ch params results =
+    byte ch 0x60;
+    vec (valtype st) ch params;
+    vec (valtype st) ch results
+
+  let subtype st ch { final; supertype; typ } =
+    (match supertype, final with
+    | None, true -> ()
+    | None, false ->
+        byte ch 0x50;
+        byte ch 0
+    | Some supertype, _ ->
+        byte ch (if final then 0X4F else 0x50);
+        byte ch 1;
+        uint ch (typeidx st supertype));
+    match typ with
+    | Array field_type ->
+        byte ch 0x5E;
+        fieldtype st ch field_type
+    | Struct l ->
+        byte ch 0x5F;
+        vec (fieldtype st) ch l
+    | Func { params; results } -> functype st ch params results
+
+  let rectype st ch l =
+    let len = Array.length l in
+    if len > 1
+    then (
+      byte ch 0x4E;
+      uint ch len);
+    Array.iter ~f:(subtype st ch) l;
+    st.type_index_count <- st.type_index_count + len
+
+  let types ch l =
+    let st = { type_index_count = 0 } in
+    vec (rectype st) ch l;
+    st
+
+  let limits ch { min; max; shared; index_type } =
+    let kind =
+      (if Option.is_none max then 0 else 1)
+      + (if shared then 2 else 0)
+      +
+      match index_type with
+      | `I64 -> 4
+      | `I32 -> 0
+    in
+    byte ch kind;
+    uint ch min;
+    Option.iter ~f:(uint ch) max
+
+  let globaltype st ch mut typ =
+    valtype st ch typ;
+    mutability ch mut
+
+  let tabletype st ch { limits = l; typ } =
+    reftype st ch typ;
+    limits ch l
+
+  let imports st ch imports =
+    vec
+      (fun ch { module_; name = nm; desc } ->
+        name ch module_;
+        name ch nm;
+        match desc with
+        | Func typ ->
+            byte ch 0x00;
+            uint ch typ
+        | Table typ ->
+            byte ch 0x01;
+            tabletype st ch typ
+        | Mem l ->
+            byte ch 0x03;
+            limits ch l
+        | Global { mut; typ } ->
+            byte ch 0x03;
+            globaltype st ch mut typ
+        | Tag typ ->
+            byte ch 0x04;
+            byte ch 0x00;
+            uint ch typ)
+      ch
+      imports
+
+  let functions = vec uint
+
+  let memtype = limits
+
+  let memories = vec memtype
+
+  let export ch kind nm idx =
+    name ch nm;
+    byte
+      ch
+      (match kind with
+      | Func -> 0
+      | Table -> 1
+      | Mem -> 2
+      | Global -> 3
+      | Tag -> 4);
+    uint ch idx
+
+  let start = uint
+
+  let tag ch tag =
+    byte ch 0;
+    uint ch tag
+
+  let tags = vec tag
+
+  let data_count = uint
+
+  let nameassoc ch idx nm =
+    uint ch idx;
+    name ch nm
+
+  let namemap = vec (fun ch (idx, name) -> nameassoc ch idx name)
+end
+
+type 'a exportable_info =
+  { mutable func : 'a
+  ; mutable table : 'a
+  ; mutable mem : 'a
+  ; mutable global : 'a
+  ; mutable tag : 'a
+  }
+
+let iter_exportable_info f { func; table; mem; global; tag } =
+  f Func func;
+  f Table table;
+  f Mem mem;
+  f Global global;
+  f Tag tag
+
+let map_exportable_info f { func; table; mem; global; tag } =
+  { func = f Func func
+  ; table = f Table table
+  ; mem = f Mem mem
+  ; global = f Global global
+  ; tag = f Tag tag
+  }
+
+let fold_exportable_info f acc { func; table; mem; global; tag } =
+  acc |> f Func func |> f Table table |> f Mem mem |> f Global global |> f Tag tag
+
+let init_exportable_info f =
+  { func = f (); table = f (); mem = f (); global = f (); tag = f () }
+
+let make_exportable_info v = init_exportable_info (fun _ -> v)
+
+let exportable_kind d =
+  match d with
+  | 0 -> Func
+  | 1 -> Table
+  | 2 -> Mem
+  | 3 -> Global
+  | 4 -> Tag
+  | _ -> assert false
+
+let get_exportable_info info kind =
+  match kind with
+  | Func -> info.func
+  | Table -> info.table
+  | Mem -> info.mem
+  | Global -> info.global
+  | Tag -> info.tag
+
+let set_exportable_info info kind v =
+  match kind with
+  | Func -> info.func <- v
+  | Table -> info.table <- v
+  | Mem -> info.mem <- v
+  | Global -> info.global <- v
+  | Tag -> info.tag <- v
+
+module Read = struct
+  let header = "\000asm\001\000\000\000"
+
+  let check_header file contents =
+    if String.length contents < 8
+       || not (String.equal header (String.sub contents ~pos:0 ~len:8))
+    then failwith (file ^ " is not a Wasm binary file (bad magic)")
+
+  type ch =
+    { buf : string
+    ; mutable pos : int
+    ; limit : int
+    }
+
+  let pos_in ch = ch.pos
+
+  let seek_in ch pos = ch.pos <- pos
+
+  let input_byte ch =
+    let pos = ch.pos in
+    ch.pos <- pos + 1;
+    Char.code ch.buf.[pos]
+
+  let peek_byte ch = Char.code ch.buf.[ch.pos]
+
+  let really_input_string ch len =
+    let pos = ch.pos in
+    ch.pos <- pos + len;
+    String.sub ch.buf ~pos ~len
+
+  let rec uint ?(n = 5) ch =
+    let i = input_byte ch in
+    if n = 1 then assert (i < 16);
+    if i < 128 then i else i - 128 + (uint ~n:(n - 1) ch lsl 7)
+
+  let rec sint ?(n = 5) ch =
+    let i = input_byte ch in
+    if n = 1 then assert (i < 8 || (i > 120 && i < 128));
+    if i < 64 then i else if i < 128 then i - 128 else i - 128 + (sint ~n:(n - 1) ch lsl 7)
+
+  let repeat n f ch = Array.init n ~f:(fun _ -> f ch)
+
+  let vec f ch = repeat (uint ch) f ch
+
+  let repeat' n f ch =
+    for _ = 1 to n do
+      f ch
+    done
+
+  let vec' f ch = repeat' (uint ch) f ch
+
+  let name ch = really_input_string ch (uint ch)
+
+  type section =
+    { id : int
+    ; pos : int
+    ; size : int
+    }
+
+  type index =
+    { sections : (int, section) Hashtbl.t
+    ; custom_sections : (string, section) Hashtbl.t
+    }
+
+  let next_section ch =
+    if pos_in ch = ch.limit
+    then None
+    else
+      let id = input_byte ch in
+      let size = uint ch in
+      Some { id; pos = pos_in ch; size }
+
+  let skip_section ch { pos; size; _ } = seek_in ch (pos + size)
+
+  let index ch =
+    let index = { sections = Hashtbl.create 16; custom_sections = Hashtbl.create 16 } in
+    let rec loop () =
+      match next_section ch with
+      | None -> index
+      | Some sect ->
+          if sect.id = 0
+          then Hashtbl.add index.custom_sections (name ch) sect
+          else Hashtbl.add index.sections sect.id sect;
+          skip_section ch sect;
+          loop ()
+    in
+    loop ()
+
+  type t =
+    { ch : ch
+    ; mutable type_mapping : int array
+    ; mutable type_index_count : int
+    ; index : index
+    }
+
+  let open_in f buf =
+    check_header f buf;
+    let ch = { buf; pos = 8; limit = String.length buf } in
+    { ch; type_mapping = [||]; type_index_count = 0; index = index ch }
+
+  let find_section contents n =
+    match Hashtbl.find contents.index.sections n with
+    | { pos; _ } ->
+        seek_in contents.ch pos;
+        true
+    | exception Not_found -> false
+
+  let get_custom_section contents name =
+    Hashtbl.find_opt contents.index.custom_sections name
+
+  let focus_on_custom_section contents section =
+    let pos, limit =
+      match get_custom_section contents section with
+      | Some { pos; size; _ } -> pos, pos + size
+      | None -> 0, 0
+    in
+    let ch = { buf = contents.ch.buf; pos; limit } in
+    if limit > 0 then ignore (name ch);
+    { contents with index = index ch }
+
+  module RecTypeTbl = Hashtbl.Make (struct
+    type t = rectype
+
+    let hash t =
+      (* We have large structs, that tend to hash to the same value *)
+      Hashtbl.hash_param 15 100 t
+
+    let heaptype_eq t1 t2 =
+      Stdlib.phys_equal t1 t2
+      ||
+      match t1, t2 with
+      | Type i1, Type i2 -> i1 = i2
+      | _ -> false
+
+    let reftype_eq { nullable = n1; typ = t1 } { nullable = n2; typ = t2 } =
+      Bool.(n1 = n2) && heaptype_eq t1 t2
+
+    let valtype_eq t1 t2 =
+      Stdlib.phys_equal t1 t2
+      ||
+      match t1, t2 with
+      | Ref t1, Ref t2 -> reftype_eq t1 t2
+      | _ -> false
+
+    let storagetype_eq t1 t2 =
+      match t1, t2 with
+      | Val v1, Val v2 -> valtype_eq v1 v2
+      | Packed p1, Packed p2 -> Stdlib.phys_equal p1 p2
+      | _ -> false
+
+    let fieldtype_eq { mut = m1; typ = t1 } { mut = m2; typ = t2 } =
+      Bool.(m1 = m2) && storagetype_eq t1 t2
+
+    (* Does not allocate and return false on length mismatch *)
+    let array_for_all2 p a1 a2 =
+      let n1 = Array.length a1 and n2 = Array.length a2 in
+      n1 = n2
+      &&
+      let rec loop p a1 a2 n1 i =
+        i = n1 || (p a1.(i) a2.(i) && loop p a1 a2 n1 (succ i))
+      in
+      loop p a1 a2 n1 0
+
+    let comptype_eq (t1 : comptype) (t2 : comptype) =
+      match t1, t2 with
+      | Func { params = p1; results = r1 }, Func { params = p2; results = r2 } ->
+          array_for_all2 valtype_eq p1 p2 && array_for_all2 valtype_eq r1 r2
+      | Struct l1, Struct l2 -> array_for_all2 fieldtype_eq l1 l2
+      | Array f1, Array f2 -> fieldtype_eq f1 f2
+      | _ -> false
+
+    let subtype_eq
+        { final = f1; supertype = s1; typ = t1 }
+        { final = f2; supertype = s2; typ = t2 } =
+      Bool.(f1 = f2)
+      && (match s1, s2 with
+         | Some _, None | None, Some _ -> false
+         | None, None -> true
+         | Some i1, Some i2 -> i1 = i2)
+      && comptype_eq t1 t2
+
+    let equal t1 t2 =
+      match t1, t2 with
+      | [| t1 |], [| t2 |] -> subtype_eq t1 t2
+      | _ -> array_for_all2 subtype_eq t1 t2
+  end)
+
+  type types =
+    { types : int RecTypeTbl.t
+    ; mutable last_index : int
+    ; mutable rev_list : rectype list
+    }
+
+  let create_types () = { types = RecTypeTbl.create 2000; last_index = 0; rev_list = [] }
+
+  let add_rectype types typ =
+    try RecTypeTbl.find types.types typ
+    with Not_found ->
+      let index = types.last_index in
+      RecTypeTbl.add types.types typ index;
+      types.last_index <- Array.length typ + index;
+      types.rev_list <- typ :: types.rev_list;
+      index
+
+  let heaptype st ch =
+    let i = sint ch in
+    match i + 128 with
+    | 0X73 -> Nofunc
+    | 0x72 -> Noextern
+    | 0x71 -> None_
+    | 0x70 -> Func
+    | 0x6F -> Extern
+    | 0x6E -> Any
+    | 0x6D -> Eq
+    | 0x6C -> I31
+    | 0x6B -> Struct
+    | 0x6A -> Array
+    | _ ->
+        if i < 0 then failwith (Printf.sprintf "Unknown heaptype %x@." i);
+        let i =
+          if i >= st.type_index_count
+          then lnot (i - st.type_index_count)
+          else st.type_mapping.(i)
+        in
+        Type i
+
+  let nullable typ = { nullable = true; typ }
+
+  let ref_eq = { nullable = false; typ = Eq }
+
+  let ref_i31 = { nullable = false; typ = I31 }
+
+  let reftype' st i ch =
+    match i with
+    | 0X73 -> nullable Nofunc
+    | 0x72 -> nullable Noextern
+    | 0x71 -> nullable None_
+    | 0x70 -> nullable Func
+    | 0x6F -> nullable Extern
+    | 0x6E -> nullable Any
+    | 0x6D -> nullable Eq
+    | 0x6C -> nullable I31
+    | 0x6B -> nullable Struct
+    | 0x6A -> nullable Array
+    | 0x63 -> nullable (heaptype st ch)
+    | 0x64 -> { nullable = false; typ = heaptype st ch }
+    | _ -> failwith (Printf.sprintf "Unknown reftype %x@." i)
+
+  let reftype st ch = reftype' st (input_byte ch) ch
+
+  let ref_i31 = Ref ref_i31
+
+  let ref_eq = Ref ref_eq
+
+  let valtype' st i ch =
+    match i with
+    | 0x7B -> V128
+    | 0x7C -> F64
+    | 0x7D -> F32
+    | 0x7E -> I64
+    | 0x7F -> I32
+    | 0x64 -> (
+        match peek_byte ch with
+        | 0x6C ->
+            ignore (input_byte ch);
+            ref_i31
+        | 0x6D ->
+            ignore (input_byte ch);
+            ref_eq
+        | _ -> Ref { nullable = false; typ = heaptype st ch })
+    | _ -> Ref (reftype' st i ch)
+
+  let valtype st ch =
+    let i = uint ch in
+    valtype' st i ch
+
+  let storagetype st ch =
+    let i = uint ch in
+    match i with
+    | 0x78 -> Packed I8
+    | 0x77 -> Packed I16
+    | _ -> Val (valtype' st i ch)
+
+  let fieldtype st ch =
+    let typ = storagetype st ch in
+    let mut = input_byte ch <> 0 in
+    { mut; typ }
+
+  let comptype st i ch =
+    match i with
+    | 0x5E -> Array (fieldtype st ch)
+    | 0x5F -> Struct (vec (fieldtype st) ch)
+    | 0x60 ->
+        let params = vec (valtype st) ch in
+        let results = vec (valtype st) ch in
+        Func { params; results }
+    | c -> failwith (Printf.sprintf "Unknown comptype %d" c)
+
+  let supertype st ch =
+    match input_byte ch with
+    | 0 -> None
+    | 1 ->
+        let t = uint ch in
+        Some
+          (if t >= st.type_index_count
+           then lnot (t - st.type_index_count)
+           else st.type_mapping.(t))
+    | _ -> assert false
+
+  let subtype st i ch =
+    match i with
+    | 0x50 ->
+        let supertype = supertype st ch in
+        { final = false; supertype; typ = comptype st (input_byte ch) ch }
+    | 0x4F ->
+        let supertype = supertype st ch in
+        { final = true; supertype; typ = comptype st (input_byte ch) ch }
+    | _ -> { final = true; supertype = None; typ = comptype st i ch }
+
+  let rectype st ch =
+    match input_byte ch with
+    | 0x4E -> vec (fun ch -> subtype st (input_byte ch) ch) ch
+    | i -> [| subtype st i ch |]
+
+  let type_section st types ch =
+    let n = uint ch in
+    st.type_mapping <- Array.make n 0;
+    st.type_index_count <- 0;
+    repeat'
+      n
+      (fun ch ->
+        let ty = rectype st ch in
+        let pos = st.type_index_count in
+        let pos' = add_rectype types ty in
+        let count = Array.length ty in
+        for i = 0 to count - 1 do
+          st.type_mapping.(pos + i) <- pos' + i
+        done;
+        st.type_index_count <- pos + count)
+      ch
+
+  let limits ch =
+    let kind = input_byte ch in
+    assert (kind < 8);
+    let shared = kind land 2 <> 0 in
+    let index_type = if kind land 4 = 0 then `I32 else `I64 in
+    let min = uint ch in
+    let max = if kind land 1 = 0 then None else Some (uint ch) in
+    { min; max; shared; index_type }
+
+  let memtype = limits
+
+  let tabletype st ch =
+    let typ = reftype st ch in
+    let limits = limits ch in
+    { limits; typ }
+
+  let typeidx st ch = st.type_mapping.(uint ch)
+
+  let globaltype st ch =
+    let typ = valtype st ch in
+    let mut = input_byte ch in
+    assert (mut < 2);
+    { mut = mut <> 0; typ }
+
+  let import tbl st ch =
+    let module_ = name ch in
+    let name = name ch in
+    let d = uint ch in
+    if d > 4 then failwith (Printf.sprintf "Unknown import %x@." d);
+    let importdesc : importdesc =
+      match d with
+      | 0 -> Func st.type_mapping.(uint ch)
+      | 1 -> Table (tabletype st ch)
+      | 2 -> Mem (memtype ch)
+      | 3 -> Global (globaltype st ch)
+      | 4 ->
+          let b = uint ch in
+          assert (b = 0);
+          Tag st.type_mapping.(uint ch)
+      | _ -> assert false
+    in
+    let entry = { module_; name; desc = importdesc } in
+    let kind = exportable_kind d in
+    set_exportable_info tbl kind (entry :: get_exportable_info tbl kind)
+
+  let export tbl ch =
+    let name = name ch in
+    let d = uint ch in
+    if d > 4 then failwith (Printf.sprintf "Unknown export %x@." d);
+    let idx = uint ch in
+    let entry = name, idx in
+    let kind = exportable_kind d in
+    set_exportable_info tbl kind (entry :: get_exportable_info tbl kind)
+
+  type interface =
+    { imports : import array exportable_info
+    ; exports : (string * int) list exportable_info
+    }
+
+  let type_section types contents =
+    if find_section contents 1 then type_section contents types contents.ch
+
+  let interface contents =
+    let imports =
+      if find_section contents 2
+      then (
+        let tbl = make_exportable_info [] in
+        vec' (import tbl contents) contents.ch;
+        map_exportable_info (fun _ l -> Array.of_list (List.rev l)) tbl)
+      else make_exportable_info [||]
+    in
+    let exports =
+      let tbl = make_exportable_info [] in
+      if find_section contents 7 then vec' (export tbl) contents.ch;
+      tbl
+    in
+    { imports; exports }
+
+  let functions contents =
+    if find_section contents 3
+    then vec (fun ch -> typeidx contents ch) contents.ch
+    else [||]
+
+  let memories contents = if find_section contents 5 then vec memtype contents.ch else [||]
+
+  let tag contents ch =
+    let b = input_byte ch in
+    assert (b = 0);
+    typeidx contents ch
+
+  let tags contents =
+    if find_section contents 13 then vec (tag contents) contents.ch else [||]
+
+  let data_count contents =
+    if find_section contents 12
+    then uint contents.ch
+    else if find_section contents 11
+    then uint contents.ch
+    else 0
+
+  let start contents = if find_section contents 8 then Some (uint contents.ch) else None
+
+  let nameassoc ch =
+    let idx = uint ch in
+    let name = name ch in
+    idx, name
+
+  let namemap contents = vec nameassoc contents.ch
+end
+
+module Scan = struct
+  let debug = false
+
+  type maps =
+    { typ : int array
+    ; func : int array
+    ; table : int array
+    ; mem : int array
+    ; global : int array
+    ; elem : int array
+    ; data : int array
+    ; tag : int array
+    }
+
+  let default_maps =
+    { typ = [||]
+    ; func = [||]
+    ; table = [||]
+    ; mem = [||]
+    ; global = [||]
+    ; elem = [||]
+    ; data = [||]
+    ; tag = [||]
+    }
+
+  type resize_data = Wa_source_map.resize_data =
+    { mutable i : int
+    ; mutable pos : int array
+    ; mutable delta : int array
+    }
+
+  let push_resize resize_data pos delta =
+    let p = resize_data.pos in
+    let i = resize_data.i in
+    let p =
+      if i = Array.length p
+      then (
+        let p = Array.make (2 * i) 0 in
+        let d = Array.make (2 * i) 0 in
+        Array.blit ~src:resize_data.pos ~src_pos:0 ~dst:p ~dst_pos:0 ~len:i;
+        Array.blit ~src:resize_data.delta ~src_pos:0 ~dst:d ~dst_pos:0 ~len:i;
+        resize_data.pos <- p;
+        resize_data.delta <- d;
+        p)
+      else p
+    in
+    p.(i) <- pos;
+    resize_data.delta.(i) <- delta;
+    resize_data.i <- i + 1
+
+  let create_resize_data () =
+    { i = 0; pos = Array.make 1024 0; delta = Array.make 1024 0 }
+
+  let clear_resize_data resize_data = resize_data.i <- 0
+
+  type position_data =
+    { mutable i : int
+    ; mutable pos : int array
+    }
+
+  let create_position_data () = { i = 0; pos = Array.make 100 0 }
+
+  let clear_position_data position_data = position_data.i <- 0
+
+  let push_position position_data pos =
+    let p = position_data.pos in
+    let i = position_data.i in
+    let p =
+      if i = Array.length p
+      then (
+        let p = Array.make (2 * i) 0 in
+        Array.blit ~src:position_data.pos ~src_pos:0 ~dst:p ~dst_pos:0 ~len:i;
+        position_data.pos <- p;
+        p)
+      else p
+    in
+    p.(i) <- pos;
+    position_data.i <- i + 1
+
+  let scanner report mark maps buf code =
+    let rec output_uint buf i =
+      if i < 128
+      then Buffer.add_char buf (Char.chr i)
+      else (
+        Buffer.add_char buf (Char.chr (128 + (i land 127)));
+        output_uint buf (i lsr 7))
+    in
+    let rec output_sint buf i =
+      if i >= -64 && i < 64
+      then Buffer.add_char buf (Char.chr (i land 127))
+      else (
+        Buffer.add_char buf (Char.chr (128 + (i land 127)));
+        output_sint buf (i asr 7))
+    in
+    let start = ref 0 in
+    let get pos = Char.code (String.get code pos) in
+    let rec int pos = if get pos >= 128 then int (pos + 1) else pos + 1 in
+    let rec uint32 pos =
+      let i = get pos in
+      if i < 128
+      then pos + 1, i
+      else
+        let pos, i' = pos + 1 |> uint32 in
+        pos, (i' lsl 7) + (i land 0x7f)
+    in
+    let rec sint32 pos =
+      let i = get pos in
+      if i < 64
+      then pos + 1, i
+      else if i < 128
+      then pos + 1, i - 128
+      else
+        let pos, i' = pos + 1 |> sint32 in
+        pos, i - 128 + (i' lsl 7)
+    in
+    let rec repeat n f pos = if n = 0 then pos else repeat (n - 1) f (f pos) in
+    let vector f pos =
+      let pos, i =
+        let i = get pos in
+        if i < 128 then pos + 1, i else uint32 pos
+      in
+      repeat i f pos
+    in
+    let name pos =
+      let pos', i =
+        let i = get pos in
+        if i < 128 then pos + 1, i else uint32 pos
+      in
+      pos' + i
+    in
+    let flush' pos pos' =
+      if !start < pos then Buffer.add_substring buf code !start (pos - !start);
+      start := pos'
+    in
+    let flush pos = flush' pos pos in
+    let rewrite map pos =
+      let pos', idx =
+        let i = get pos in
+        if i < 128
+        then pos + 1, i
+        else
+          let i' = get (pos + 1) in
+          if i' < 128 then pos + 2, (i' lsl 7) + (i land 0x7f) else uint32 pos
+      in
+      let idx' = map idx in
+      if idx <> idx'
+      then (
+        flush' pos pos';
+        let p = Buffer.length buf in
+        output_uint buf idx';
+        let p' = Buffer.length buf in
+        let dp = p' - p in
+        let dpos = pos' - pos in
+        if dp <> dpos then report pos (dp - dpos));
+      pos'
+    in
+    let rewrite_signed map pos =
+      let pos', idx =
+        let i = get pos in
+        if i < 64 then pos + 1, i else if i < 128 then pos + 1, i - 128 else sint32 pos
+      in
+      let idx' = map idx in
+      if idx <> idx'
+      then (
+        flush' pos pos';
+        let p = Buffer.length buf in
+        output_sint buf idx';
+        let p' = Buffer.length buf in
+        let dp = p' - p in
+        let dpos = pos' - pos in
+        if dp <> dpos then report pos (dp - dpos));
+      pos'
+    in
+    let typ_map idx = maps.typ.(idx) in
+    let typeidx pos = rewrite typ_map pos in
+    let signed_typeidx pos = rewrite_signed typ_map pos in
+    let func_map idx = maps.func.(idx) in
+    let funcidx pos = rewrite func_map pos in
+    let table_map idx = maps.table.(idx) in
+    let tableidx pos = rewrite table_map pos in
+    let mem_map idx = maps.mem.(idx) in
+    let memidx pos = rewrite mem_map pos in
+    let global_map idx = maps.global.(idx) in
+    let globalidx pos = rewrite global_map pos in
+    let elem_map idx = maps.elem.(idx) in
+    let elemidx pos = rewrite elem_map pos in
+    let data_map idx = maps.data.(idx) in
+    let dataidx pos = rewrite data_map pos in
+    let tag_map idx = maps.tag.(idx) in
+    let tagidx pos = rewrite tag_map pos in
+    let labelidx = int in
+    let localidx = int in
+    let laneidx pos = pos + 1 in
+    let heaptype pos =
+      let c = get pos in
+      if c >= 64 && c < 128 then (* absheaptype *) pos + 1 else signed_typeidx pos
+    in
+    let absheaptype pos =
+      match get pos with
+      | 0X73 (* nofunc *)
+      | 0x72 (* noextern *)
+      | 0x71 (* none *)
+      | 0x70 (* func *)
+      | 0x6F (* extern *)
+      | 0x6E (* any *)
+      | 0x6D (* eq *)
+      | 0x6C (* i31 *)
+      | 0x6B (* struct *)
+      | 0x6A (* array *) -> pos + 1
+      | c -> failwith (Printf.sprintf "Bad heap type 0x%02X@." c)
+    in
+    let reftype pos =
+      match get pos with
+      | 0x63 | 0x64 -> pos + 1 |> heaptype
+      | _ -> pos |> absheaptype
+    in
+    let valtype pos =
+      let c = get pos in
+      match c with
+      | 0x63 (* ref null ht *) | 0x64 (* ref ht *) -> pos + 1 |> heaptype
+      | _ -> pos + 1
+    in
+    let blocktype pos =
+      let c = get pos in
+      if c >= 64 && c < 128 then pos |> valtype else pos |> signed_typeidx
+    in
+    let memarg pos =
+      let pos', c = uint32 pos in
+      if c < 64
+      then (
+        if mem_map 0 <> 0
+        then (
+          flush' pos pos';
+          let p = Buffer.length buf in
+          output_uint buf (c + 64);
+          output_uint buf (mem_map 0);
+          let p' = Buffer.length buf in
+          let dp = p' - p in
+          let dpos = pos' - pos in
+          if dp <> dpos then report pos (dp - dpos));
+        pos' |> int)
+      else pos' |> memidx |> int
+    in
+    let rec instructions pos =
+      if debug then Format.eprintf "0x%02X (@%d)@." (get pos) pos;
+      match get pos with
+      (* Control instruction *)
+      | 0x00 (* unreachable *) | 0x01 (* nop *) | 0x0F (* return *) ->
+          pos + 1 |> instructions
+      | 0x02 (* block *) | 0x03 (* loop *) ->
+          pos + 1 |> blocktype |> instructions |> block_end |> instructions
+      | 0x04 (* if *) -> pos + 1 |> blocktype |> instructions |> opt_else |> instructions
+      | 0x0C (* br *)
+      | 0x0D (* br_if *)
+      | 0xD5 (* br_on_null *)
+      | 0xD6 (* br_on_non_null *) -> pos + 1 |> labelidx |> instructions
+      | 0x0E (* br_table *) -> pos + 1 |> vector labelidx |> labelidx |> instructions
+      | 0x10 (* call *) | 0x12 (* return_call *) -> pos + 1 |> funcidx |> instructions
+      | 0x11 (* call_indirect *) | 0x13 (* return_call_indirect *) ->
+          pos + 1 |> typeidx |> tableidx |> instructions
+      | 0x14 (* call_ref *) | 0x15 (* return_call_ref *) ->
+          pos + 1 |> typeidx |> instructions
+      (* Exceptions *)
+      | 0x06 (* try *) -> pos + 1 |> blocktype |> instructions |> opt_catch
+      | 0x08 (* throw *) -> pos + 1 |> tagidx |> instructions
+      | 0x09 (* rethrow *) -> pos + 1 |> int |> instructions
+      | 0x0A (* throw_ref *) -> pos + 1 |> instructions
+      (* Parametric instructions *)
+      | 0x1A (* drop *) | 0x1B (* select *) -> pos + 1 |> instructions
+      | 0x1C (* select *) -> pos + 1 |> vector valtype |> instructions
+      | 0x1F (* try_table *) ->
+          pos + 1
+          |> blocktype
+          |> vector catch
+          |> instructions
+          |> block_end
+          |> instructions
+      (* Variable instructions *)
+      | 0x20 (* local.get *) | 0x21 (* local.set *) | 0x22 (* local.tee *) ->
+          pos + 1 |> localidx |> instructions
+      | 0x23 (* global.get *) | 0x24 (* global.set *) ->
+          pos + 1 |> globalidx |> instructions
+      (* Table instructions *)
+      | 0x25 (* table.get *) | 0x26 (* table.set *) -> pos + 1 |> tableidx |> instructions
+      (* Memory instructions *)
+      | 0x28
+      | 0x29
+      | 0x2A
+      | 0x2B
+      | 0x2C
+      | 0x2D
+      | 0x2E
+      | 0x2F
+      | 0x30
+      | 0x31
+      | 0x32
+      | 0x33
+      | 0x34
+      | 0x35 (* load *)
+      | 0x36 | 0x37 | 0x38 | 0x39 | 0x3A | 0x3B | 0x3C | 0x3D | 0x3E (* store *) ->
+          pos + 1 |> memarg |> instructions
+      | 0x3F | 0x40 -> pos + 1 |> memidx |> instructions
+      (* Numeric instructions *)
+      | 0x41 (* i32.const *) | 0x42 (* i64.const *) -> pos + 1 |> int |> instructions
+      | 0x43 (* f32.const *) -> pos + 5 |> instructions
+      | 0x44 (* f64.const *) -> pos + 9 |> instructions
+      | 0x45
+      | 0x46
+      | 0x47
+      | 0x48
+      | 0x49
+      | 0x4A
+      | 0x4B
+      | 0x4C
+      | 0x4D
+      | 0x4E
+      | 0x4F
+      | 0x50
+      | 0x51
+      | 0x52
+      | 0x53
+      | 0x54
+      | 0x55
+      | 0x56
+      | 0x57
+      | 0x58
+      | 0x59
+      | 0x5A
+      | 0x5B
+      | 0x5C
+      | 0x5D
+      | 0x5E
+      | 0x5F
+      | 0x60
+      | 0x61
+      | 0x62
+      | 0x63
+      | 0x64
+      | 0x65
+      | 0x66
+      | 0x67
+      | 0x68
+      | 0x69
+      | 0x6A
+      | 0x6B
+      | 0x6C
+      | 0x6D
+      | 0x6E
+      | 0x6F
+      | 0x70
+      | 0x71
+      | 0x72
+      | 0x73
+      | 0x74
+      | 0x75
+      | 0x76
+      | 0x77
+      | 0x78
+      | 0x79
+      | 0x7A
+      | 0x7B
+      | 0x7C
+      | 0x7D
+      | 0x7E
+      | 0x7F
+      | 0x80
+      | 0x81
+      | 0x82
+      | 0x83
+      | 0x84
+      | 0x85
+      | 0x86
+      | 0x87
+      | 0x88
+      | 0x89
+      | 0x8A
+      | 0x8B
+      | 0x8C
+      | 0x8D
+      | 0x8E
+      | 0x8F
+      | 0x90
+      | 0x91
+      | 0x92
+      | 0x93
+      | 0x94
+      | 0x95
+      | 0x96
+      | 0x97
+      | 0x98
+      | 0x99
+      | 0x9A
+      | 0x9B
+      | 0x9C
+      | 0x9D
+      | 0x9E
+      | 0x9F
+      | 0xA0
+      | 0xA1
+      | 0xA2
+      | 0xA3
+      | 0xA4
+      | 0xA5
+      | 0xA6
+      | 0xA7
+      | 0xA8
+      | 0xA9
+      | 0xAA
+      | 0xAB
+      | 0xAC
+      | 0xAD
+      | 0xAE
+      | 0xAF
+      | 0xB0
+      | 0xB1
+      | 0xB2
+      | 0xB3
+      | 0xB4
+      | 0xB5
+      | 0xB6
+      | 0xB7
+      | 0xB8
+      | 0xB9
+      | 0xBA
+      | 0xBB
+      | 0xBC
+      | 0xBD
+      | 0xBE
+      | 0xBF
+      | 0xC0
+      | 0xC1
+      | 0xC2
+      | 0xC3
+      | 0xC4 -> pos + 1 |> instructions
+      (* Reference instructions *)
+      | 0xD0 (* ref.null *) -> pos + 1 |> heaptype |> instructions
+      | 0xD1 (* ref.is_null *) | 0xD3 (* ref.eq *) | 0xD4 (* ref.as_non_null *) ->
+          pos + 1 |> instructions
+      | 0xD2 (* ref.func *) -> pos + 1 |> funcidx |> instructions
+      | 0xFB -> pos + 1 |> gc_instruction
+      | 0xFC -> (
+          if debug then Format.eprintf "  %d@." (get (pos + 1));
+          match get (pos + 1) with
+          | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 (* xx.trunc_sat_xxx_x *) ->
+              pos + 2 |> instructions
+          | 8 (* memory.init *) -> pos + 2 |> dataidx |> memidx |> instructions
+          | 9 (* data.drop *) -> pos + 2 |> dataidx |> instructions
+          | 10 (* memory.copy *) -> pos + 2 |> memidx |> memidx |> instructions
+          | 11 (* memory.fill *) -> pos + 2 |> memidx |> instructions
+          | 12 (* table.init *) -> pos + 2 |> elemidx |> tableidx |> instructions
+          | 13 (* elem.drop *) -> pos + 2 |> elemidx |> instructions
+          | 14 (* table.copy *) -> pos + 2 |> tableidx |> tableidx |> instructions
+          | 15 (* table.grow *) | 16 (* table.size *) | 17 (* table.fill *) ->
+              pos + 2 |> tableidx |> instructions
+          | c -> failwith (Printf.sprintf "Bad instruction 0xFC 0x%02X" c))
+      | 0xFD -> pos + 1 |> vector_instruction
+      | 0xFE -> pos + 1 |> atomic_instruction
+      | _ -> pos
+    and gc_instruction pos =
+      if debug then Format.eprintf "  %d@." (get pos);
+      match get pos with
+      | 0 (* struct.new *)
+      | 1 (* struct.new_default *)
+      | 6 (* array.new *)
+      | 7 (* array.new_default *)
+      | 11 (* array.get *)
+      | 12 (* array.get_s *)
+      | 13 (* array.get_u *)
+      | 14 (* array.set *)
+      | 16 (* array.fill *) -> pos + 1 |> typeidx |> instructions
+      | 2 (* struct.get *)
+      | 3 (* struct.get_s *)
+      | 4 (* struct.get_u *)
+      | 5 (* struct.set *)
+      | 8 (* array.new_fixed *) -> pos + 1 |> typeidx |> int |> instructions
+      | 9 (* array.new_data *) | 18 (* array.init_data *) ->
+          pos + 1 |> typeidx |> dataidx |> instructions
+      | 10 (* array.new_elem *) | 19 (* array.init_elem *) ->
+          pos + 1 |> typeidx |> elemidx |> instructions
+      | 15 (* array.len *)
+      | 26 (* any.convert_extern *)
+      | 27 (* extern.convert_any *)
+      | 28 (* ref.i31 *)
+      | 29 (* i31.get_s *)
+      | 30 (* i31.get_u *) -> pos + 1 |> instructions
+      | 17 (* array.copy *) -> pos + 1 |> typeidx |> typeidx |> instructions
+      | 20 | 21 (* ref_test *) | 22 | 23 (* ref.cast*) ->
+          pos + 1 |> heaptype |> instructions
+      | 24 (* br_on_cast *) | 25 (* br_on_cast_fail *) ->
+          pos + 2 |> labelidx |> heaptype |> heaptype |> instructions
+      | c -> failwith (Printf.sprintf "Bad instruction 0xFB 0x%02X" c)
+    and vector_instruction pos =
+      if debug then Format.eprintf "  %d@." (get pos);
+      let pos, i = uint32 pos in
+      match i with
+      | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 92 | 93 (* v128.load / store *)
+        -> pos + 1 |> memarg |> instructions
+      | 84 | 85 | 86 | 87 | 88 | 89 | 90 | 91 (* v128.load/store_lane *) ->
+          pos + 1 |> memarg |> laneidx |> instructions
+      | 12 (* v128.const *) | 13 (* v128.shuffle *) -> pos + 17 |> instructions
+      | 21
+      | 22
+      | 23
+      | 24
+      | 25
+      | 26
+      | 27
+      | 28
+      | 29
+      | 30
+      | 31
+      | 32
+      | 33
+      | 34 (* xx.extract/replace_lane *) -> pos + 1 |> laneidx |> instructions
+      | ( 162
+        | 165
+        | 166
+        | 175
+        | 176
+        | 178
+        | 179
+        | 180
+        | 187
+        | 194
+        | 197
+        | 198
+        | 207
+        | 208
+        | 210
+        | 211
+        | 212
+        | 226
+        | 238 ) as c -> failwith (Printf.sprintf "Bad instruction 0xFD 0x%02X" c)
+      | c ->
+          if c <= 275
+          then pos + 1 |> instructions
+          else failwith (Printf.sprintf "Bad instruction 0xFD 0x%02X" c)
+    and atomic_instruction pos =
+      if debug then Format.eprintf "  %d@." (get pos);
+      match get pos with
+      | 0 (* memory.atomic.notify *)
+      | 1 | 2 (* memory.atomic.waitxx *)
+      | 16 | 17 | 18 | 19 | 20 | 21 | 22 (* xx.atomic.load *)
+      | 23 | 24 | 25 | 26 | 27 | 28 | 29 (* xx.atomic.store *)
+      | 30 | 31 | 32 | 33 | 34 | 35 | 36 (* xx.atomic.rmw.add *)
+      | 37 | 38 | 39 | 40 | 41 | 42 | 43 (* xx.atomic.rmw.sub *)
+      | 44 | 45 | 46 | 47 | 48 | 49 | 50 (* xx.atomic.rmw.and *)
+      | 51 | 52 | 53 | 54 | 55 | 56 | 57 (* xx.atomic.rmw.or *)
+      | 58 | 59 | 60 | 61 | 62 | 63 | 64 (* xx.atomic.rmw.xor *)
+      | 65 | 66 | 67 | 68 | 69 | 70 | 71 (* xx.atomic.rmw.xchg *)
+      | 72 | 73 | 74 | 75 | 76 | 77 | 78 (* xx.atomic.rmw.cmpxchg *) ->
+          pos + 1 |> memarg |> instructions
+      | 3 (* memory.fence *) ->
+          let c = get pos + 1 in
+          assert (c = 0);
+          pos + 2 |> instructions
+      | c -> failwith (Printf.sprintf "Bad instruction 0xFE 0x%02X" c)
+    and opt_else pos =
+      if debug then Format.eprintf "0x%02X (@%d) else@." (get pos) pos;
+      match get pos with
+      | 0x05 (* else *) -> pos + 1 |> instructions |> block_end |> instructions
+      | _ -> pos |> block_end |> instructions
+    and opt_catch pos =
+      if debug then Format.eprintf "0x%02X (@%d) catch@." (get pos) pos;
+      match get pos with
+      | 0x07 (* catch *) -> pos + 1 |> tagidx |> instructions |> opt_catch
+      | 0x05 (* catch_all *) -> pos + 1 |> instructions |> block_end |> instructions
+      | _ -> pos |> block_end |> instructions
+    and catch pos =
+      match get pos with
+      | 0 (* catch *) | 1 (* catch_ref *) -> pos + 1 |> tagidx |> labelidx
+      | 2 (* catch_all *) | 3 (* catch_all_ref *) -> pos + 1 |> labelidx
+      | c -> failwith (Printf.sprintf "bad catch 0x02%d@." c)
+    and block_end pos =
+      if debug then Format.eprintf "0x%02X (@%d) block end@." (get pos) pos;
+      match get pos with
+      | 0x0B -> pos + 1
+      | c -> failwith (Printf.sprintf "Bad instruction 0x%02X" c)
+    in
+    let locals pos = pos |> int |> valtype in
+    let expr pos = pos |> instructions |> block_end in
+    let func pos =
+      start := pos;
+      pos |> vector locals |> expr |> flush
+    in
+    let mut pos = pos + 1 in
+    let limits pos =
+      let c = get pos in
+      assert (c < 8);
+      if c land 1 = 0 then pos |> int else pos |> int |> int
+    in
+    let tabletype pos =
+      mark pos;
+      pos |> reftype |> limits
+    in
+    let table pos =
+      match get pos with
+      | 0x40 ->
+          assert (get (pos + 1) = 0);
+          pos + 2 |> tabletype |> expr
+      | _ -> pos |> tabletype
+    in
+    let table_section ~count pos =
+      start := pos;
+      pos |> repeat count table |> flush
+    in
+    let globaltype pos =
+      mark pos;
+      pos |> valtype |> mut
+    in
+    let global pos = pos |> globaltype |> expr in
+    let global_section ~count pos =
+      start := pos;
+      pos |> repeat count global |> flush
+    in
+    let elemkind pos =
+      assert (get pos = 0);
+      pos + 1
+    in
+    let elem pos =
+      match get pos with
+      | 0 -> pos + 1 |> expr |> vector funcidx
+      | 1 -> pos + 1 |> elemkind |> vector funcidx
+      | 2 -> pos + 1 |> tableidx |> expr |> elemkind |> vector funcidx
+      | 3 -> pos + 1 |> elemkind |> vector funcidx
+      | 4 -> pos + 1 |> expr |> vector expr
+      | 5 -> pos + 1 |> reftype |> vector expr
+      | 6 -> pos + 1 |> tableidx |> expr |> reftype |> vector expr
+      | 7 -> pos + 1 |> reftype |> vector expr
+      | c -> failwith (Printf.sprintf "Bad element 0x%02X" c)
+    in
+    let bytes pos =
+      let pos, len = uint32 pos in
+      pos + len
+    in
+    let data pos =
+      match get pos with
+      | 0 -> pos + 1 |> expr |> bytes
+      | 1 -> pos + 1 |> bytes
+      | 2 -> pos + 1 |> memidx |> expr |> bytes
+      | c -> failwith (Printf.sprintf "Bad data segment 0x%02X" c)
+    in
+    let elem_section ~count pos =
+      start := pos;
+      !start |> repeat count elem |> flush
+    in
+    let data_section ~count pos =
+      start := pos;
+      !start |> repeat count data |> flush
+    in
+    let local_nameassoc pos = pos |> localidx |> name in
+    let local_namemap pos =
+      start := pos;
+      pos |> vector local_nameassoc |> flush
+    in
+    table_section, global_section, elem_section, data_section, func, local_namemap
+
+  let table_section positions maps buf s =
+    let table_section, _, _, _, _, _ =
+      scanner (fun _ _ -> ()) (fun pos -> push_position positions pos) maps buf s
+    in
+    table_section
+
+  let global_section positions maps buf s =
+    let _, global_section, _, _, _, _ =
+      scanner (fun _ _ -> ()) (fun pos -> push_position positions pos) maps buf s
+    in
+    global_section
+
+  let elem_section maps buf s =
+    let _, _, elem_section, _, _, _ = scanner (fun _ _ -> ()) (fun _ -> ()) maps buf s in
+    elem_section
+
+  let data_section maps buf s =
+    let _, _, _, data_section, _, _ = scanner (fun _ _ -> ()) (fun _ -> ()) maps buf s in
+    data_section
+
+  let func resize_data maps buf s =
+    let _, _, _, _, func, _ =
+      scanner
+        (fun pos delta -> push_resize resize_data pos delta)
+        (fun _ -> ())
+        maps
+        buf
+        s
+    in
+    func
+
+  let local_namemap buf s =
+    let _, _, _, _, _, local_namemap =
+      scanner (fun _ _ -> ()) (fun _ -> ()) default_maps buf s
+    in
+    local_namemap
+end
+
+let interface types contents =
+  Read.type_section types contents;
+  Read.interface contents
+
+type t =
+  { module_name : string
+  ; file : string
+  ; contents : Read.t
+  ; source_map_contents : Wa_source_map.t option
+  }
+
+type import_status =
+  | Resolved of int * int
+  | Unresolved of int
+
+let check_limits export import =
+  export.min >= import.min
+  &&
+  match export.max, import.max with
+  | _, None -> true
+  | None, Some _ -> false
+  | Some e, Some i -> e <= i
+
+let rec subtype subtyping_info (i : int) i' =
+  i = i'
+  ||
+  match subtyping_info.(i).supertype with
+  | None -> false
+  | Some s -> subtype subtyping_info s i'
+
+let heap_subtype (subtyping_info : subtype array) (ty : heaptype) (ty' : heaptype) =
+  match ty, ty' with
+  | (Func | Nofunc), Func
+  | Nofunc, Nofunc
+  | (Extern | Noextern), Extern
+  | (Any | Eq | I31 | Struct | Array | None_ | Type _), Any
+  | (Eq | I31 | Struct | Array | None_ | Type _), Eq
+  | (I31 | None_), I31
+  | (Struct | None_), Struct
+  | (Array | None_), Array
+  | None_, None_ -> true
+  | Type i, Struct -> (
+      match subtyping_info.(i).typ with
+      | Struct _ -> true
+      | Array _ | Func _ -> false)
+  | Type i, Array -> (
+      match subtyping_info.(i).typ with
+      | Array _ -> true
+      | Struct _ | Func _ -> false)
+  | Type i, Func -> (
+      match subtyping_info.(i).typ with
+      | Func _ -> true
+      | Struct _ | Array _ -> false)
+  | Type i, Type i' -> subtype subtyping_info i i'
+  | _ -> false
+
+let ref_subtype subtyping_info { nullable; typ } { nullable = nullable'; typ = typ' } =
+  ((not nullable) || nullable') && heap_subtype subtyping_info typ typ'
+
+let val_subtype subtyping_info ty ty' =
+  match ty, ty' with
+  | Ref t, Ref t' -> ref_subtype subtyping_info t t'
+  | _ -> Stdlib.phys_equal ty ty'
+
+let check_export_import_types ~subtyping_info ~files i (desc : importdesc) i' import =
+  let ok =
+    match desc, import.desc with
+    | Func t, Func t' -> subtype subtyping_info t t'
+    | Table { limits; typ }, Table { limits = limits'; typ = typ' } ->
+        check_limits limits limits' && Poly.(typ = typ')
+    | Mem limits, Mem limits' -> check_limits limits limits'
+    | Global { mut; typ }, Global { mut = mut'; typ = typ' } ->
+        Bool.(mut = mut')
+        && if mut then Poly.(typ = typ') else val_subtype subtyping_info typ typ'
+    | Tag t, Tag t' -> t = t'
+    | _ -> false
+  in
+  if not ok
+  then
+    failwith
+      (Printf.sprintf
+         "In module %s, the import %s / %s refers to an export in module %s of an \
+          incompatible type"
+         files.(i').file
+         import.module_
+         import.name
+         files.(i).file)
+
+let build_mappings resolved_imports unresolved_imports kind counts =
+  let current_offset = ref (get_exportable_info unresolved_imports kind) in
+  let mappings =
+    Array.mapi
+      ~f:(fun i count ->
+        let imports = get_exportable_info resolved_imports.(i) kind in
+        let import_count = Array.length imports in
+        let offset = !current_offset - import_count in
+        current_offset := !current_offset + count;
+        Array.init
+          (Array.length imports + count)
+          ~f:(fun i ->
+            if i < import_count
+            then
+              match imports.(i) with
+              | Unresolved i -> i
+              | Resolved _ -> -1
+            else i + offset))
+      counts
+  in
+  Array.iteri
+    ~f:(fun i map ->
+      let imports = get_exportable_info resolved_imports.(i) kind in
+      for i = 0 to Array.length imports - 1 do
+        match imports.(i) with
+        | Unresolved _ -> ()
+        | Resolved (j, k) -> map.(i) <- mappings.(j).(k)
+      done)
+    mappings;
+  mappings
+
+let build_simple_mappings ~counts =
+  let current_offset = ref 0 in
+  Array.map
+    ~f:(fun count ->
+      let offset = !current_offset in
+      current_offset := !current_offset + count;
+      Array.init count ~f:(fun j -> j + offset))
+    counts
+
+let add_section out_ch ~id ?count buf =
+  match count with
+  | Some 0 -> Buffer.clear buf
+  | _ ->
+      let buf' = Buffer.create 5 in
+      Option.iter ~f:(fun c -> Write.uint buf' c) count;
+      output_byte out_ch id;
+      output_uint out_ch (Buffer.length buf' + Buffer.length buf);
+      Buffer.output_buffer out_ch buf';
+      Buffer.output_buffer out_ch buf;
+      Buffer.clear buf
+
+let add_subsection buf ~id ?count buf' =
+  match count with
+  | Some 0 -> Buffer.clear buf'
+  | _ ->
+      let buf'' = Buffer.create 5 in
+      Option.iter ~f:(fun c -> Write.uint buf'' c) count;
+      Buffer.add_char buf (Char.chr id);
+      Write.uint buf (Buffer.length buf'' + Buffer.length buf');
+      Buffer.add_buffer buf buf'';
+      Buffer.add_buffer buf buf';
+      Buffer.clear buf'
+
+let check_exports_against_imports
+    ~intfs
+    ~subtyping_info
+    ~resolved_imports
+    ~files
+    ~kind
+    ~to_desc =
+  Array.iteri
+    ~f:(fun i intf ->
+      let imports = get_exportable_info intf.Read.imports kind in
+      let statuses = get_exportable_info resolved_imports.(i) kind in
+      Array.iter2
+        ~f:(fun import status ->
+          match status with
+          | Unresolved _ -> ()
+          | Resolved (i', idx') -> (
+              match to_desc i' idx' with
+              | None -> ()
+              | Some desc ->
+                  check_export_import_types ~subtyping_info ~files i' desc i import))
+        imports
+        statuses)
+    intfs
+
+let read_desc_from_file ~intfs ~files ~positions ~read i j =
+  let offset = Array.length (get_exportable_info intfs.(i).Read.imports Table) in
+  if j < offset
+  then None
+  else
+    let { contents; _ } = files.(i) in
+    Read.seek_in contents.ch positions.(i).Scan.pos.(j - offset);
+    Some (read contents)
+
+let index_in_output ~unresolved_imports ~mappings ~kind ~get i' idx' =
+  let offset = get_exportable_info unresolved_imports kind in
+  let idx'' = mappings.(i').(idx') - offset in
+  if idx'' >= 0 then Some (get idx'') else None
+
+let write_simple_section
+    ~intfs
+    ~subtyping_info
+    ~resolved_imports
+    ~unresolved_imports
+    ~files
+    ~out_ch
+    ~buf
+    ~kind
+    ~id
+    ~read
+    ~to_type
+    ~write =
+  let data = Array.map ~f:(fun f -> read f.contents) files in
+  let entries = Array.concat (Array.to_list data) in
+  if Array.length entries <> 0
+  then (
+    write buf entries;
+    add_section out_ch ~id buf);
+  let counts = Array.map ~f:Array.length data in
+  let mappings = build_mappings resolved_imports unresolved_imports kind counts in
+  check_exports_against_imports
+    ~intfs
+    ~subtyping_info
+    ~resolved_imports
+    ~files
+    ~kind
+    ~to_desc:
+      (index_in_output ~unresolved_imports ~mappings ~kind ~get:(fun idx ->
+           to_type entries.(idx)));
+  mappings
+
+let write_section_with_scan ~files ~out_ch ~buf ~id ~scan =
+  let counts =
+    Array.mapi
+      ~f:(fun i { contents; _ } ->
+        if Read.find_section contents id
+        then (
+          let count = Read.uint contents.ch in
+          scan
+            i
+            { Scan.default_maps with typ = contents.type_mapping }
+            buf
+            contents.ch.buf
+            ~count
+            contents.ch.pos;
+          count)
+        else 0)
+      files
+  in
+  add_section out_ch ~id ~count:(Array.fold_left ~f:( + ) ~init:0 counts) buf;
+  counts
+
+let write_simple_namemap ~name_sections ~name_section_buffer ~buf ~section_id ~mappings =
+  let count = ref 0 in
+  Array.iter2
+    ~f:(fun name_section mapping ->
+      if Read.find_section name_section section_id
+      then (
+        let map = Read.namemap name_section in
+        Array.iter ~f:(fun (idx, name) -> Write.nameassoc buf mapping.(idx) name) map;
+        count := !count + Array.length map))
+    name_sections
+    mappings;
+  add_subsection name_section_buffer ~id:section_id ~count:!count buf
+
+let write_namemap
+    ~resolved_imports
+    ~unresolved_imports
+    ~name_sections
+    ~name_section_buffer
+    ~buf
+    ~kind
+    ~section_id
+    ~mappings =
+  let import_names = Array.make (get_exportable_info unresolved_imports kind) None in
+  Array.iteri
+    ~f:(fun i name_section ->
+      if Read.find_section name_section section_id
+      then
+        let imports = get_exportable_info resolved_imports.(i) kind in
+        let import_count = Array.length imports in
+        let n = Read.uint name_section.ch in
+        let rec loop j =
+          if j < n
+          then
+            let idx = Read.uint name_section.ch in
+            let name = Read.name name_section.ch in
+            if idx < import_count
+            then (
+              let idx' =
+                match imports.(idx) with
+                | Unresolved idx' -> idx'
+                | Resolved (i', idx') -> mappings.(i').(idx')
+              in
+              if idx' < Array.length import_names && Option.is_none import_names.(idx')
+              then import_names.(idx') <- Some name;
+              loop (j + 1))
+        in
+        loop 0)
+    name_sections;
+  let count = ref 0 in
+  Array.iteri
+    ~f:(fun idx name ->
+      match name with
+      | None -> ()
+      | Some name ->
+          incr count;
+          Write.nameassoc buf idx name)
+    import_names;
+  Array.iteri
+    ~f:(fun i name_section ->
+      if Read.find_section name_section section_id
+      then
+        let mapping = mappings.(i) in
+        let imports = get_exportable_info resolved_imports.(i) kind in
+        let import_count = Array.length imports in
+        let n = Read.uint name_section.ch in
+        let ch = name_section.ch in
+        for _ = 1 to n do
+          let idx = Read.uint ch in
+          let len = Read.uint ch in
+          if idx >= import_count
+          then (
+            incr count;
+            Write.uint buf mapping.(idx);
+            Write.uint buf len;
+            Buffer.add_substring buf ch.buf ch.pos len);
+          ch.pos <- ch.pos + len
+        done)
+    name_sections;
+  add_subsection name_section_buffer ~id:section_id ~count:!count buf
+
+let write_indirectnamemap ~name_sections ~name_section_buffer ~buf ~section_id ~mappings =
+  let count = ref 0 in
+  Array.iter2
+    ~f:(fun name_section mapping ->
+      if Read.find_section name_section section_id
+      then (
+        let n = Read.uint name_section.ch in
+        let scan_map = Scan.local_namemap buf name_section.ch.buf in
+        for _ = 1 to n do
+          let idx = mapping.(Read.uint name_section.ch) in
+          Write.uint buf idx;
+          let p = Buffer.length buf in
+          scan_map name_section.ch.pos;
+          name_section.ch.pos <- name_section.ch.pos + Buffer.length buf - p
+        done;
+        count := !count + n))
+    name_sections
+    mappings;
+  add_subsection name_section_buffer ~id:section_id ~count:!count buf
+
+let rec resolve
+    depth
+    ~files
+    ~intfs
+    ~subtyping_info
+    ~exports
+    ~kind
+    i
+    ({ module_; name; _ } as import) =
+  let i', index = Hashtbl.find exports (module_, name) in
+  let imports = get_exportable_info intfs.(i').Read.imports kind in
+  if index < Array.length imports
+  then (
+    if depth > 100 then failwith (Printf.sprintf "Import loop on %s %s" module_ name);
+    let entry = imports.(index) in
+    check_export_import_types ~subtyping_info ~files i' entry.desc i import;
+    try resolve (depth + 1) ~files ~intfs ~subtyping_info ~exports ~kind i' entry
+    with Not_found -> i', index)
+  else i', index
+
+type input =
+  { module_name : string
+  ; file : string
+  ; code : string option
+  ; opt_source_map : [ `File of string | `Data of string ] option
+  }
+
+let f files ~output_file ~opt_output_sourcemap_file =
+  let files =
+    let tmp_buf = Buffer.create 10000 in
+    Array.map
+      ~f:(fun { module_name; file; code; opt_source_map } ->
+        let data =
+          match code with
+          | None -> Fs.read_file file
+          | Some data -> data
+        in
+        let contents = Read.open_in file data in
+        { module_name
+        ; file
+        ; contents
+        ; source_map_contents =
+            Option.map
+              ~f:(fun src ->
+                match src with
+                | `File file -> Wa_source_map.load ~tmp_buf file
+                | `Data data -> Wa_source_map.parse ~tmp_buf data)
+              opt_source_map
+        })
+      (Array.of_list files)
+  in
+
+  let out_ch = open_out output_file in
+  output_string out_ch Read.header;
+  let buf = Buffer.create 100000 in
+
+  (* 1: type *)
+  let types = Read.create_types () in
+  let intfs = Array.map ~f:(fun f -> interface types f.contents) files in
+  let type_list = List.rev types.rev_list in
+  let subtyping_info = Array.concat type_list in
+  let st = Write.types buf (Array.of_list type_list) in
+  add_section out_ch ~id:1 buf;
+
+  (* 2: import *)
+  let exports = init_exportable_info (fun _ -> Hashtbl.create 128) in
+  Array.iteri
+    ~f:(fun i intf ->
+      iter_exportable_info
+        (fun kind lst ->
+          let h = get_exportable_info exports kind in
+          List.iter
+            ~f:(fun (name, index) ->
+              Hashtbl.add h (files.(i).module_name, name) (i, index))
+            lst)
+        intf.Read.exports)
+    intfs;
+  let import_list = ref [] in
+  let unresolved_imports = make_exportable_info 0 in
+  let resolved_imports =
+    let tbl = Hashtbl.create 128 in
+    Array.mapi
+      ~f:(fun i intf ->
+        map_exportable_info
+          (fun kind imports ->
+            let exports = get_exportable_info exports kind in
+            Array.map
+              ~f:(fun (import : import) ->
+                match resolve 0 ~files ~intfs ~subtyping_info ~exports ~kind i import with
+                | i', idx -> Resolved (i', idx)
+                | exception Not_found -> (
+                    match Hashtbl.find tbl import with
+                    | status -> status
+                    | exception Not_found ->
+                        let idx = get_exportable_info unresolved_imports kind in
+                        let status = Unresolved idx in
+                        Hashtbl.replace tbl import status;
+                        set_exportable_info unresolved_imports kind (1 + idx);
+                        import_list := import :: !import_list;
+                        status))
+              imports)
+          intf.Read.imports)
+      intfs
+  in
+  Write.imports st buf (Array.of_list (List.rev !import_list));
+  add_section out_ch ~id:2 buf;
+
+  let start_count =
+    Array.fold_left
+      ~f:(fun count f ->
+        match Read.start f.contents with
+        | None -> count
+        | Some _ -> count + 1)
+      ~init:0
+      files
+  in
+
+  (* 3: function *)
+  let functions = Array.map ~f:(fun f -> Read.functions f.contents) files in
+  let func_types =
+    let l = Array.to_list functions in
+    let l =
+      if start_count > 1
+      then
+        let ty =
+          let typ : comptype = Func { params = [||]; results = [||] } in
+          Read.add_rectype types [| { final = true; supertype = None; typ } |]
+        in
+        l @ [ [| ty |] ]
+      else l
+    in
+    Array.concat l
+  in
+  Write.functions buf func_types;
+  add_section out_ch ~id:3 buf;
+  let func_counts = Array.map ~f:Array.length functions in
+  let func_mappings =
+    build_mappings resolved_imports unresolved_imports Func func_counts
+  in
+  let func_count =
+    Array.fold_left ~f:( + ) ~init:(if start_count > 1 then 1 else 0) func_counts
+  in
+  check_exports_against_imports
+    ~intfs
+    ~subtyping_info
+    ~resolved_imports
+    ~files
+    ~kind:Func
+    ~to_desc:
+      (index_in_output
+         ~unresolved_imports
+         ~mappings:func_mappings
+         ~kind:Func
+         ~get:(fun idx : importdesc -> Func func_types.(idx)));
+
+  (* 4: table *)
+  let positions =
+    Array.init (Array.length files) ~f:(fun _ -> Scan.create_position_data ())
+  in
+  let table_counts =
+    write_section_with_scan ~files ~out_ch ~buf ~id:4 ~scan:(fun i maps ->
+        Scan.table_section positions.(i) { maps with func = func_mappings.(i) })
+  in
+  let table_mappings =
+    build_mappings resolved_imports unresolved_imports Table table_counts
+  in
+  check_exports_against_imports
+    ~intfs
+    ~subtyping_info
+    ~resolved_imports
+    ~files
+    ~kind:Table
+    ~to_desc:
+      (read_desc_from_file ~intfs ~files ~positions ~read:(fun contents : importdesc ->
+           Table (Read.tabletype contents contents.ch)));
+  Array.iter ~f:Scan.clear_position_data positions;
+
+  (* 5: memory *)
+  let mem_mappings =
+    write_simple_section
+      ~intfs
+      ~subtyping_info
+      ~resolved_imports
+      ~unresolved_imports
+      ~out_ch
+      ~buf
+      ~kind:Mem
+      ~id:5
+      ~read:Read.memories
+      ~to_type:(fun limits -> Mem limits)
+      ~write:Write.memories
+      ~files
+  in
+
+  (* 13: tag *)
+  let tag_mappings =
+    write_simple_section
+      ~intfs
+      ~subtyping_info
+      ~resolved_imports
+      ~unresolved_imports
+      ~out_ch
+      ~buf
+      ~kind:Tag
+      ~id:13
+      ~read:Read.tags
+      ~to_type:(fun ty -> Tag ty)
+      ~write:Write.tags
+      ~files
+  in
+
+  (* 6: global *)
+  let global_mappings = Array.make (Array.length files) [||] in
+  let global_counts =
+    let current_offset = ref (get_exportable_info unresolved_imports Global) in
+    Array.mapi
+      ~f:(fun i { file; contents; _ } ->
+        let imports = get_exportable_info resolved_imports.(i) Global in
+        let import_count = Array.length imports in
+        let offset = !current_offset - import_count in
+        let build_map count =
+          let map =
+            Array.init
+              (Array.length imports + count)
+              ~f:(fun j ->
+                if j < import_count
+                then (
+                  match imports.(j) with
+                  | Unresolved j' -> j'
+                  | Resolved (i', j') ->
+                      (if i' > i
+                       then
+                         let import =
+                           (get_exportable_info intfs.(i).imports Global).(j)
+                         in
+                         failwith
+                           (Printf.sprintf
+                              "In module %s, the import %s / %s refers to an export in a \
+                               later module %s"
+                              file
+                              import.module_
+                              import.name
+                              files.(i').file));
+                      global_mappings.(i').(j'))
+                else j + offset)
+          in
+          global_mappings.(i) <- map;
+          map
+        in
+        let count =
+          if Read.find_section contents 6
+          then (
+            let count = Read.uint contents.ch in
+            let map = build_map count in
+            Scan.global_section
+              positions.(i)
+              { Scan.default_maps with
+                typ = contents.type_mapping
+              ; func = func_mappings.(i)
+              ; global = map
+              }
+              buf
+              contents.ch.buf
+              contents.ch.pos
+              ~count;
+            count)
+          else (
+            ignore (build_map 0);
+            0)
+        in
+        current_offset := !current_offset + count;
+        count)
+      files
+  in
+  add_section out_ch ~id:6 ~count:(Array.fold_left ~f:( + ) ~init:0 global_counts) buf;
+  check_exports_against_imports
+    ~intfs
+    ~subtyping_info
+    ~resolved_imports
+    ~files
+    ~kind:Global
+    ~to_desc:(fun i j : importdesc option ->
+      let offset = Array.length (get_exportable_info intfs.(i).imports Global) in
+      if j < offset
+      then None
+      else
+        let { contents; _ } = files.(i) in
+        Read.seek_in contents.ch positions.(i).pos.(j - offset);
+        Some (Global (Read.globaltype contents contents.ch)));
+  Array.iter ~f:Scan.clear_position_data positions;
+
+  (* 7: export *)
+  let export_count =
+    Array.fold_left
+      ~f:(fun count intf ->
+        fold_exportable_info
+          (fun _ exports count -> List.length exports + count)
+          count
+          intf.Read.exports)
+      ~init:0
+      intfs
+  in
+  Write.uint buf export_count;
+  let exports = Hashtbl.create 128 in
+  Array.iteri
+    ~f:(fun i intf ->
+      iter_exportable_info
+        (fun kind lst ->
+          let map =
+            match kind with
+            | Func -> func_mappings.(i)
+            | Table -> table_mappings.(i)
+            | Mem -> mem_mappings.(i)
+            | Global -> global_mappings.(i)
+            | Tag -> tag_mappings.(i)
+          in
+          List.iter
+            ~f:(fun (name, idx) ->
+              match Hashtbl.find exports name with
+              | i' ->
+                  failwith
+                    (Printf.sprintf
+                       "Duplicated export %s from %s and %s"
+                       name
+                       files.(i').file
+                       files.(i).file)
+              | exception Not_found ->
+                  Hashtbl.add exports name i;
+                  Write.export buf kind name map.(idx))
+            lst)
+        intf.Read.exports)
+    intfs;
+  add_section out_ch ~id:7 buf;
+
+  (* 8: start *)
+  let starts =
+    Array.mapi
+      ~f:(fun i f ->
+        Read.start f.contents |> Option.map ~f:(fun idx -> func_mappings.(i).(idx)))
+      files
+    |> Array.to_list
+    |> List.filter_map ~f:(fun x -> x)
+  in
+  (match starts with
+  | [] -> ()
+  | [ start ] ->
+      Write.start buf start;
+      add_section out_ch ~id:8 buf
+  | _ :: _ :: _ ->
+      Write.start buf (func_count - 1);
+      add_section out_ch ~id:8 buf);
+
+  (* 9: elements *)
+  let elem_counts =
+    write_section_with_scan ~files ~out_ch ~buf ~id:9 ~scan:(fun i maps ->
+        Scan.elem_section
+          { maps with func = func_mappings.(i); global = global_mappings.(i) })
+  in
+  let elem_mappings = build_simple_mappings ~counts:elem_counts in
+
+  (* 12: data count *)
+  let data_mappings, data_count =
+    let data_counts = Array.map ~f:(fun f -> Read.data_count f.contents) files in
+    let data_count = Array.fold_left ~f:( + ) ~init:0 data_counts in
+    let data_mappings = build_simple_mappings ~counts:data_counts in
+    data_mappings, data_count
+  in
+  if data_count > 0
+  then (
+    Write.data_count buf data_count;
+    add_section out_ch ~id:12 buf);
+
+  (* 10: code *)
+  let code_pieces = Buffer.create 100000 in
+  let resize_data = Scan.create_resize_data () in
+  let source_maps = ref [] in
+  Write.uint code_pieces func_count;
+  Array.iteri
+    ~f:(fun i { contents; source_map_contents; _ } ->
+      if Read.find_section contents 10
+      then (
+        let pos = Buffer.length code_pieces in
+        let scan_func =
+          Scan.func
+            resize_data
+            { typ = contents.type_mapping
+            ; func = func_mappings.(i)
+            ; table = table_mappings.(i)
+            ; mem = mem_mappings.(i)
+            ; global = global_mappings.(i)
+            ; elem = elem_mappings.(i)
+            ; data = data_mappings.(i)
+            ; tag = tag_mappings.(i)
+            }
+            buf
+            contents.ch.buf
+        in
+        let code (ch : Read.ch) =
+          let pos = ch.pos in
+          let i = resize_data.i in
+          Scan.push_resize resize_data pos 0;
+          let size = Read.uint ch in
+          let pos' = ch.pos in
+          scan_func ch.pos;
+          ch.pos <- ch.pos + size;
+          let p = Buffer.length code_pieces in
+          Write.uint code_pieces (Buffer.length buf);
+          let p' = Buffer.length code_pieces in
+          let delta = p' - p - pos' + pos in
+          resize_data.delta.(i) <- delta;
+          Buffer.add_buffer code_pieces buf;
+          Buffer.clear buf
+        in
+        let count = Read.uint contents.ch in
+        Scan.clear_resize_data resize_data;
+        Scan.push_resize resize_data 0 (-Read.pos_in contents.ch);
+        Read.repeat' count code contents.ch;
+        Option.iter
+          ~f:(fun sm ->
+            if not (Wa_source_map.is_empty sm)
+            then source_maps := (pos, Wa_source_map.resize resize_data sm) :: !source_maps)
+          source_map_contents))
+    files;
+  if start_count > 1
+  then (
+    (* no local *)
+    Buffer.add_char buf (Char.chr 0);
+    List.iter
+      ~f:(fun idx ->
+        (* call idx *)
+        Buffer.add_char buf (Char.chr 0x10);
+        Write.uint buf idx)
+      starts;
+    Buffer.add_buffer code_pieces buf;
+    Buffer.clear buf);
+  let code_section_offset =
+    let b = Buffer.create 5 in
+    Write.uint b (Buffer.length code_pieces);
+    pos_out out_ch + 1 + Buffer.length b
+  in
+  add_section out_ch ~id:10 code_pieces;
+  Option.iter
+    ~f:(fun file ->
+      Wa_source_map.write
+        file
+        (Wa_source_map.concatenate
+           (List.map
+              ~f:(fun (pos, sm) -> pos + code_section_offset, sm)
+              (List.rev !source_maps))))
+    opt_output_sourcemap_file;
+
+  (* 11: data *)
+  ignore
+    (write_section_with_scan ~files ~out_ch ~buf ~id:11 ~scan:(fun i maps ->
+         Scan.data_section { maps with global = global_mappings.(i) }));
+
+  (* Custom section: name *)
+  let name_sections =
+    Array.map
+      ~f:(fun { contents; _ } -> Read.focus_on_custom_section contents "name")
+      files
+  in
+  let name_section_buffer = Buffer.create 100000 in
+  Write.name name_section_buffer "name";
+
+  (* 1: functions *)
+  write_namemap
+    ~resolved_imports
+    ~unresolved_imports
+    ~name_sections
+    ~name_section_buffer
+    ~buf
+    ~kind:Func
+    ~section_id:1
+    ~mappings:func_mappings;
+  (* 2: locals *)
+  write_indirectnamemap
+    ~name_sections
+    ~name_section_buffer
+    ~buf
+    ~section_id:2
+    ~mappings:func_mappings;
+  (* 3: labels *)
+  write_indirectnamemap
+    ~name_sections
+    ~name_section_buffer
+    ~buf
+    ~section_id:3
+    ~mappings:func_mappings;
+
+  (* 4: types *)
+  let type_names = Array.make types.last_index None in
+  Array.iter2
+    ~f:(fun { contents; _ } name_section ->
+      if Read.find_section name_section 4
+      then
+        let map = Read.namemap name_section in
+        Array.iter
+          ~f:(fun (idx, name) ->
+            let idx = contents.type_mapping.(idx) in
+            if Option.is_none type_names.(idx) then type_names.(idx) <- Some (idx, name))
+          map)
+    files
+    name_sections;
+  Write.namemap
+    buf
+    (Array.of_list (List.filter_map ~f:(fun x -> x) (Array.to_list type_names)));
+  add_subsection name_section_buffer ~id:4 buf;
+
+  (* 5: tables *)
+  write_namemap
+    ~resolved_imports
+    ~unresolved_imports
+    ~name_sections
+    ~name_section_buffer
+    ~buf
+    ~kind:Table
+    ~section_id:5
+    ~mappings:table_mappings;
+  (* 6: memories *)
+  write_namemap
+    ~resolved_imports
+    ~unresolved_imports
+    ~name_sections
+    ~name_section_buffer
+    ~buf
+    ~kind:Mem
+    ~section_id:6
+    ~mappings:mem_mappings;
+  (* 7: globals *)
+  write_namemap
+    ~resolved_imports
+    ~unresolved_imports
+    ~name_sections
+    ~name_section_buffer
+    ~buf
+    ~kind:Global
+    ~section_id:7
+    ~mappings:global_mappings;
+  (* 8: elems *)
+  write_simple_namemap
+    ~name_sections
+    ~name_section_buffer
+    ~buf
+    ~section_id:8
+    ~mappings:elem_mappings;
+  (* 9: data segments *)
+  write_simple_namemap
+    ~name_sections
+    ~name_section_buffer
+    ~buf
+    ~section_id:9
+    ~mappings:data_mappings;
+
+  (* 10: field names *)
+  let type_field_names = Array.make types.last_index None in
+  Array.iter2
+    ~f:(fun { contents; _ } name_section ->
+      if Read.find_section name_section 10
+      then
+        let n = Read.uint name_section.ch in
+        let scan_map = Scan.local_namemap buf name_section.ch.buf in
+        for _ = 1 to n do
+          let idx = contents.type_mapping.(Read.uint name_section.ch) in
+          scan_map name_section.ch.pos;
+          name_section.ch.pos <- name_section.ch.pos + Buffer.length buf;
+          if Option.is_none type_field_names.(idx)
+          then type_field_names.(idx) <- Some (idx, Buffer.contents buf);
+          Buffer.clear buf
+        done)
+    files
+    name_sections;
+  let type_field_names =
+    Array.of_list (List.filter_map ~f:(fun x -> x) (Array.to_list type_field_names))
+  in
+  Write.uint buf (Array.length type_field_names);
+  for i = 0 to Array.length type_field_names - 1 do
+    let idx, map = type_field_names.(i) in
+    Write.uint buf idx;
+    Buffer.add_string buf map
+  done;
+  add_subsection name_section_buffer ~id:10 buf;
+
+  (* 11: tags *)
+  write_namemap
+    ~resolved_imports
+    ~unresolved_imports
+    ~name_sections
+    ~name_section_buffer
+    ~buf
+    ~kind:Tag
+    ~section_id:11
+    ~mappings:tag_mappings;
+
+  add_section out_ch ~id:0 name_section_buffer;
+
+  close_out out_ch
+
+(*
+LATER
+- testsuite : import/export matching, source maps, multiple start functions, ...
+- missing instructions ==> typed continuations (?)
+- check features?
+
+MAYBE
+- topologic sort of globals?
+  => easy: just look at the import/export dependencies between modules
+- reorder types/globals/functions to generate a smaller binary
+*)

--- a/compiler/lib/wasm/wa_wasm_link.mli
+++ b/compiler/lib/wasm/wa_wasm_link.mli
@@ -1,0 +1,9 @@
+type input =
+  { module_name : string
+  ; file : string
+  ; code : string option
+  ; opt_source_map : [ `File of string | `Data of string ] option
+  }
+
+val f :
+  input list -> output_file:string -> opt_output_sourcemap_file:string option -> unit

--- a/compiler/lib/wasm/wa_wasm_output.ml
+++ b/compiler/lib/wasm/wa_wasm_output.ml
@@ -1,0 +1,1184 @@
+open! Stdlib
+open Wa_ast
+
+module Feature : sig
+  type set
+
+  val make : unit -> set
+
+  val get : set -> string list
+
+  type t
+
+  val register : set -> string -> t
+
+  val require : t -> unit
+
+  val test : t -> bool
+end = struct
+  type t = string * bool ref
+
+  type set = t list ref
+
+  let make () = ref []
+
+  let get l = !l |> List.filter ~f:(fun (_, b) -> !b) |> List.map ~f:fst
+
+  let register l name =
+    let f = name, ref false in
+    l := f :: !l;
+    f
+
+  let require (_, b) = b := true
+
+  let test (_, b) = !b
+end
+
+module Make (Output : sig
+  type t
+
+  val position : t -> int
+
+  val seek : t -> int -> unit
+
+  val byte : t -> int -> unit
+
+  val string : t -> string -> unit
+end) : sig
+  val output_module : Output.t -> module_field list -> unit
+end = struct
+  let features = Feature.make ()
+
+  let mutable_globals = Feature.register features "mutable-globals"
+
+  let nontrapping_fptoint = Feature.register features "nontrapping-fptoint"
+
+  let multivalue = Feature.register features "multivalue"
+
+  let exception_handling = Feature.register features "exception-handling"
+
+  let tail_call = Feature.register features "tail-call"
+
+  let bulk_memory = Feature.register features "bulk-memory"
+
+  let gc = Feature.register features "gc"
+
+  let reference_types = Feature.register features "reference-types"
+
+  let position = Output.position
+
+  let seek = Output.seek
+
+  let output_byte = Output.byte
+
+  let output_string = Output.string
+
+  let rec output_uint ch i =
+    if i < 128
+    then output_byte ch i
+    else (
+      output_byte ch (128 + (i land 127));
+      output_uint ch (i lsr 7))
+
+  let rec output_sint ch i =
+    if i >= -64 && i < 64
+    then output_byte ch (i land 127)
+    else (
+      output_byte ch (128 + (i land 127));
+      output_sint ch (i asr 7))
+
+  let output_sint32 ch i =
+    if Poly.(i >= -64l && i < 64l)
+    then
+      let i = Int32.to_int i in
+      if i >= 0 then output_byte ch i else output_byte ch (i + 128)
+    else (
+      output_byte ch (128 + (Int32.to_int i land 127));
+      output_sint ch (Int32.to_int (Int32.shift_right i 7)))
+
+  let rec output_sint64 ch i =
+    if Poly.(i >= -64L && i < 64L)
+    then
+      let i = Int64.to_int i in
+      if i >= 0 then output_byte ch i else output_byte ch (i + 128)
+    else (
+      output_byte ch (128 + (Int64.to_int i land 127));
+      output_sint64 ch (Int64.shift_right i 7))
+
+  let output_bytes32 ch v =
+    let v = ref v in
+    for _ = 0 to 3 do
+      output_byte ch (Int32.to_int !v land 255);
+      v := Int32.shift_right !v 8
+    done
+
+  let output_bytes64 ch v =
+    let v = ref v in
+    for _ = 0 to 7 do
+      output_byte ch (Int64.to_int !v land 255);
+      v := Int64.shift_right !v 8
+    done
+
+  let output_f32 ch f = output_bytes32 ch (Int32.bits_of_float f)
+
+  let output_f64 ch f = output_bytes64 ch (Int64.bits_of_float f)
+
+  let output_name ch name =
+    output_uint ch (String.length name);
+    output_string ch name
+
+  let output_vec f ch l =
+    output_uint ch (List.length l);
+    List.iter ~f:(fun x -> f ch x) l
+
+  let output_uint32_placeholder ch =
+    let pos = position ch in
+    output_string ch "\x80\x80\x80\x80\x00";
+    pos
+
+  let output_uint32_fixed ch ~pos v =
+    let pos' = position ch in
+    seek ch pos;
+    let v = ref v in
+    for _ = 0 to 3 do
+      output_byte ch ((!v land 0x7f) + 128);
+      v := !v lsr 7
+    done;
+    output_byte ch !v;
+    seek ch pos'
+
+  let with_size f ch x =
+    let pos = output_uint32_placeholder ch in
+    let res = f ch x in
+    output_uint32_fixed ch ~pos (position ch - pos - 5);
+    res
+
+  (****)
+  let output_heaptype type_names ch typ =
+    match (typ : heap_type) with
+    | Func -> output_byte ch 0x70
+    | Extern -> output_byte ch 0x6F
+    | Any -> output_byte ch 0x6E
+    | Eq -> output_byte ch 0x6D
+    | I31 -> output_byte ch 0x6C
+    | Type nm -> output_sint ch (Hashtbl.find type_names nm)
+
+  let output_valtype type_names ch (typ : value_type) =
+    match typ with
+    | I32 -> output_byte ch 0x7F
+    | I64 -> output_byte ch 0x7E
+    | F32 -> output_byte ch 0x7D
+    | F64 -> output_byte ch 0x7C
+    | Ref { nullable; typ } ->
+        output_byte ch (if nullable then 0x63 else 0x64);
+        output_heaptype type_names ch typ
+
+  let output_mut ch mut = output_byte ch (if mut then 0x01 else 0x00)
+
+  let output_fieldtype type_names ch { mut; typ } =
+    (match typ with
+    | Value typ -> output_valtype type_names ch typ
+    | Packed typ -> (
+        match typ with
+        | I8 -> output_byte ch 0x78
+        | I16 -> output_byte ch 0x77));
+    output_mut ch mut
+
+  let output_functype type_names ch { params; result } =
+    if List.length result > 1 then Feature.require multivalue;
+    output_byte ch 0x60;
+    output_vec (output_valtype type_names) ch params;
+    output_vec (output_valtype type_names) ch result
+
+  let output_globaltype type_names ch { typ; mut } =
+    output_valtype type_names ch typ;
+    output_mut ch mut
+
+  let fold_types func_type explicit_definition acc fields =
+    List.fold_left
+      ~f:(fun acc field ->
+        match field with
+        | Function { typ; _ } | Import { desc = Fun typ; _ } -> func_type acc typ
+        | Import { desc = Tag typ; _ } -> func_type acc { params = [ typ ]; result = [] }
+        | Type l -> explicit_definition acc l
+        | Import { desc = Global _; _ } | Data _ | Global _ | Tag _ -> acc)
+      ~init:acc
+      fields
+
+  let output_types ch fields =
+    let count =
+      let func_types = Hashtbl.create 16 in
+      fold_types
+        (fun count typ ->
+          if Hashtbl.mem func_types typ
+          then count
+          else (
+            Hashtbl.add func_types typ ();
+            count + 1))
+        (fun count _ -> count + 1)
+        0
+        fields
+    in
+    output_uint ch count;
+    let func_types = Hashtbl.create 16 in
+    let type_names = Hashtbl.create 16 in
+    let _idx =
+      fold_types
+        (fun idx typ ->
+          if Hashtbl.mem func_types typ
+          then idx
+          else (
+            Hashtbl.add func_types typ idx;
+            output_functype type_names ch typ;
+            idx + 1))
+        (fun idx l ->
+          let len = List.length l in
+          if List.length l > 1
+          then (
+            output_byte ch 0x4E;
+            output_uint ch len);
+          List.fold_left
+            ~f:(fun idx { name; typ; supertype; final } ->
+              Hashtbl.add type_names name idx;
+              (match supertype, final with
+              | None, true -> ()
+              | None, false ->
+                  output_byte ch 0x50;
+                  output_byte ch 0
+              | Some supertype, _ ->
+                  output_byte ch (if final then 0X4F else 0x50);
+                  output_byte ch 1;
+                  output_uint ch (Hashtbl.find type_names supertype));
+              (match typ with
+              | Array field_type ->
+                  output_byte ch 0x5E;
+                  output_fieldtype type_names ch field_type
+              | Struct l ->
+                  output_byte ch 0x5F;
+                  output_vec (output_fieldtype type_names) ch l
+              | Func typ -> output_functype type_names ch typ);
+              idx + 1)
+            ~init:idx
+            l)
+        0
+        fields
+    in
+    func_types, type_names
+
+  let output_imports ch (func_types, type_names, fields) =
+    let count =
+      List.fold_left
+        ~f:(fun count field ->
+          match field with
+          | Import _ -> count + 1
+          | Function _ | Type _ | Data _ | Global _ | Tag _ -> count)
+        ~init:0
+        fields
+    in
+    output_uint ch count;
+    let func_idx = ref 0 in
+    let func_names = Hashtbl.create 16 in
+    let global_idx = ref 0 in
+    let global_names = Hashtbl.create 16 in
+    let tag_idx = ref 0 in
+    let tag_names = Hashtbl.create 16 in
+    List.iter
+      ~f:(fun field ->
+        match field with
+        | Function _ | Type _ | Data _ | Global _ | Tag _ -> ()
+        | Import { import_module; import_name; name; desc } -> (
+            output_name ch import_module;
+            output_name ch import_name;
+            match desc with
+            | Fun typ ->
+                output_byte ch 0x00;
+                output_uint ch (Hashtbl.find func_types typ);
+                Hashtbl.add func_names name !func_idx;
+                incr func_idx
+            | Global typ ->
+                if typ.mut then Feature.require mutable_globals;
+                output_byte ch 0x03;
+                output_globaltype type_names ch typ;
+                Hashtbl.add global_names (V name) !global_idx;
+                incr global_idx
+            | Tag typ ->
+                Feature.require exception_handling;
+                output_byte ch 0x04;
+                output_byte ch 0x00;
+                output_uint ch (Hashtbl.find func_types { params = [ typ ]; result = [] });
+                Hashtbl.add tag_names name !tag_idx;
+                incr tag_idx))
+      fields;
+    !func_idx, func_names, !global_idx, global_names, !tag_idx, tag_names
+
+  let output_functions ch (func_idx, func_names, func_types, fields) =
+    let l =
+      List.fold_left
+        ~f:(fun acc field ->
+          match field with
+          | Function { typ; _ } -> typ :: acc
+          | Type _ | Import _ | Data _ | Global _ | Tag _ -> acc)
+        ~init:[]
+        fields
+    in
+    let _ =
+      List.fold_left
+        ~f:(fun idx field ->
+          match field with
+          | Function { name; _ } ->
+              Hashtbl.add func_names name idx;
+              idx + 1
+          | Type _ | Import _ | Data _ | Global _ | Tag _ -> idx)
+        ~init:func_idx
+        fields
+    in
+    output_vec
+      (fun ch typ -> output_uint ch (Hashtbl.find func_types typ))
+      ch
+      (List.rev l)
+
+  let int_un_op (arith, comp, trunc, reinterpret) ch op =
+    match op with
+    | Clz -> output_byte ch arith
+    | Ctz -> output_byte ch (arith + 1)
+    | Popcnt -> output_byte ch (arith + 2)
+    | Eqz -> output_byte ch comp
+    | TruncSatF64 signage ->
+        Feature.require nontrapping_fptoint;
+        output_byte ch 0xFC;
+        output_byte
+          ch
+          (trunc
+          +
+          match signage with
+          | S -> 0
+          | U -> 1)
+    | ReinterpretF -> output_byte ch reinterpret
+
+  let int_bin_op (arith, comp) op =
+    match (op : int_bin_op) with
+    | Add -> arith + 3
+    | Sub -> arith + 4
+    | Mul -> arith + 5
+    | Div S -> arith + 6
+    | Div U -> arith + 7
+    | Rem S -> arith + 8
+    | Rem U -> arith + 9
+    | And -> arith + 10
+    | Or -> arith + 11
+    | Xor -> arith + 12
+    | Shl -> arith + 13
+    | Shr S -> arith + 14
+    | Shr U -> arith + 15
+    | Rotl -> arith + 16
+    | Rotr -> arith + 17
+    | Eq -> comp + 1
+    | Ne -> comp + 2
+    | Lt S -> comp + 3
+    | Lt U -> comp + 4
+    | Gt S -> comp + 5
+    | Gt U -> comp + 6
+    | Le S -> comp + 7
+    | Le U -> comp + 8
+    | Ge S -> comp + 9
+    | Ge U -> comp + 10
+
+  let float_un_op (arith, convert, reinterpret) op =
+    match op with
+    | Abs -> arith
+    | Neg -> arith + 1
+    | Ceil -> arith + 2
+    | Floor -> arith + 3
+    | Trunc -> arith + 4
+    | Nearest -> arith + 5
+    | Sqrt -> arith + 6
+    | Convert (size, signage) -> (
+        convert
+        + (match size with
+          | `I32 -> 0
+          | `I64 -> 2)
+        +
+        match signage with
+        | S -> 0
+        | U -> 1)
+    | ReinterpretI -> reinterpret
+
+  let float_bin_op (arith, comp) op =
+    match op with
+    | Add -> arith + 7
+    | Sub -> arith + 8
+    | Mul -> arith + 9
+    | Div -> arith + 10
+    | Min -> arith + 11
+    | Max -> arith + 12
+    | CopySign -> arith + 13
+    | Eq -> comp
+    | Ne -> comp + 1
+    | Lt -> comp + 2
+    | Gt -> comp + 3
+    | Le -> comp + 4
+    | Ge -> comp + 5
+
+  let output_blocktype type_names ch typ =
+    match typ with
+    | { params = []; result = [] } -> output_byte ch 0x40
+    | { params = []; result = [ typ ] } -> output_valtype type_names ch typ
+    | _ -> assert false
+
+  type st =
+    { type_names : (var, int) Hashtbl.t
+    ; func_names : (var, int) Hashtbl.t
+    ; global_names : (symbol, int) Hashtbl.t
+    ; data_names : (var, int) Hashtbl.t
+    ; tag_names : (var, int) Hashtbl.t
+    ; local_names : (var, (var, int) Hashtbl.t) Hashtbl.t
+    ; current_local_names : (var, int) Hashtbl.t
+    }
+
+  let rec output_expression st ch e =
+    match e with
+    | Const c -> (
+        match c with
+        | I32 d ->
+            output_byte ch 0x41;
+            output_sint32 ch d
+        | I64 d ->
+            output_byte ch 0x42;
+            output_sint64 ch d
+        | F32 d ->
+            output_byte ch 0x43;
+            output_f32 ch d
+        | F64 d ->
+            output_byte ch 0x44;
+            output_f64 ch d)
+    | UnOp (op, e') -> (
+        output_expression st ch e';
+        match op with
+        | I32 op -> int_un_op (0x67, 0x45, 2, 0xBC) ch op
+        | I64 op -> int_un_op (0x79, 0x50, 6, 0xBD) ch op
+        | F32 op -> output_byte ch (float_un_op (0x8B, 0xB2, 0xBE) op)
+        | F64 op -> output_byte ch (float_un_op (0x99, 0xB7, 0xBF) op))
+    | BinOp (op, e', e'') -> (
+        output_expression st ch e';
+        output_expression st ch e'';
+        match op with
+        | I32 op -> output_byte ch (int_bin_op (0x67, 0x45) op)
+        | I64 op -> output_byte ch (int_bin_op (0x79, 0x50) op)
+        | F32 op -> output_byte ch (float_bin_op (0x8B, 0x5B) op)
+        | F64 op -> output_byte ch (float_bin_op (0x99, 0x61) op))
+    | I32WrapI64 e' ->
+        output_expression st ch e';
+        output_byte ch 0xA7
+    | I64ExtendI32 (S, e') ->
+        output_expression st ch e';
+        output_byte ch 0xAC
+    | I64ExtendI32 (U, e') ->
+        output_expression st ch e';
+        output_byte ch 0xAD
+    | F32DemoteF64 e' ->
+        output_expression st ch e';
+        output_byte ch 0xB6
+    | F64PromoteF32 e' ->
+        output_expression st ch e';
+        output_byte ch 0xBB
+    | Call_indirect _ | ConstSym _ | Load _ | Load8 _ | MemoryGrow _ -> assert false
+    | LocalGet i ->
+        output_byte ch 0x20;
+        output_uint ch (Hashtbl.find st.current_local_names i)
+    | LocalTee (i, e') ->
+        output_expression st ch e';
+        output_byte ch 0x22;
+        output_uint ch (Hashtbl.find st.current_local_names i)
+    | GlobalGet g ->
+        output_byte ch 0x23;
+        output_uint ch (Hashtbl.find st.global_names g)
+    | BlockExpr (typ, l) ->
+        output_byte ch 0x02;
+        output_blocktype st.type_names ch typ;
+        List.iter ~f:(fun i' -> output_instruction st ch i') l;
+        output_byte ch 0x0B
+    | Call (f, l) ->
+        List.iter ~f:(fun e' -> output_expression st ch e') l;
+        output_byte ch 0x10;
+        output_uint ch (Hashtbl.find st.func_names f)
+    | Seq _ -> assert false
+    | Pop _ -> ()
+    | RefFunc f ->
+        Feature.require reference_types;
+        output_byte ch 0xD2;
+        output_uint ch (Hashtbl.find st.func_names f)
+    | Call_ref (typ, e', l) ->
+        Feature.require gc;
+        List.iter ~f:(fun e' -> output_expression st ch e') l;
+        output_expression st ch e';
+        output_byte ch 0x14;
+        output_uint ch (Hashtbl.find st.type_names typ)
+    | RefI31 e' ->
+        Feature.require gc;
+        output_expression st ch e';
+        output_byte ch 0xFB;
+        output_byte ch 0x1C
+    | I31Get (s, e') -> (
+        Feature.require gc;
+        output_expression st ch e';
+        output_byte ch 0xFB;
+        match s with
+        | S -> output_byte ch 0x1D
+        | U -> output_byte ch 0x1E)
+    | ArrayNew (typ, e', e'') ->
+        Feature.require gc;
+        output_expression st ch e';
+        output_expression st ch e'';
+        output_byte ch 0xFB;
+        output_byte ch 6;
+        output_uint ch (Hashtbl.find st.type_names typ)
+    | ArrayNewFixed (typ, l) ->
+        Feature.require gc;
+        List.iter ~f:(fun e' -> output_expression st ch e') l;
+        output_byte ch 0xFB;
+        output_byte ch 8;
+        output_uint ch (Hashtbl.find st.type_names typ);
+        output_uint ch (List.length l)
+    | ArrayNewData (typ, data, e', e'') ->
+        Feature.require gc;
+        output_expression st ch e';
+        output_expression st ch e'';
+        output_byte ch 0xFB;
+        output_byte ch 9;
+        output_uint ch (Hashtbl.find st.type_names typ);
+        output_uint ch (Hashtbl.find st.data_names data)
+    | ArrayGet (signage, typ, e', e'') ->
+        Feature.require gc;
+        output_expression st ch e';
+        output_expression st ch e'';
+        output_byte ch 0xFB;
+        output_byte
+          ch
+          (match signage with
+          | None -> 0x0B
+          | Some S -> 0x0C
+          | Some U -> 0x0D);
+        output_uint ch (Hashtbl.find st.type_names typ)
+    | ArrayLen e' ->
+        Feature.require gc;
+        output_expression st ch e';
+        output_byte ch 0xFB;
+        output_byte ch 0x0F
+    | StructNew (typ, l) ->
+        Feature.require gc;
+        List.iter ~f:(fun e' -> output_expression st ch e') l;
+        output_byte ch 0xFB;
+        output_byte ch 0;
+        output_uint ch (Hashtbl.find st.type_names typ)
+    | StructGet (signage, typ, idx, e') ->
+        Feature.require gc;
+        output_expression st ch e';
+        output_byte ch 0xFB;
+        output_byte
+          ch
+          (match signage with
+          | None -> 0x02
+          | Some S -> 0x03
+          | Some U -> 0x04);
+        output_uint ch (Hashtbl.find st.type_names typ);
+        output_uint ch idx
+    | RefCast ({ typ; nullable }, e') ->
+        Feature.require gc;
+        output_expression st ch e';
+        output_byte ch 0xFB;
+        output_byte ch (if nullable then 0x17 else 0x16);
+        output_heaptype st.type_names ch typ
+    | RefTest ({ typ; nullable }, e') ->
+        Feature.require gc;
+        output_expression st ch e';
+        output_byte ch 0xFB;
+        output_byte ch (if nullable then 0x15 else 0x14);
+        output_heaptype st.type_names ch typ
+    | RefEq (e', e'') ->
+        Feature.require gc;
+        output_expression st ch e';
+        output_expression st ch e'';
+        output_byte ch 0xD3
+    | RefNull typ ->
+        Feature.require reference_types;
+        output_byte ch 0xD0;
+        output_heaptype st.type_names ch typ
+    | Br_on_cast (i, typ1, typ2, e') ->
+        Feature.require gc;
+        output_expression st ch e';
+        output_byte ch 0xFB;
+        output_byte ch 0x18;
+        output_byte ch ((if typ1.nullable then 1 else 0) + if typ2.nullable then 2 else 0);
+        output_uint ch i;
+        output_heaptype st.type_names ch typ1.typ;
+        output_heaptype st.type_names ch typ2.typ
+    | Br_on_cast_fail (i, typ1, typ2, e') ->
+        Feature.require gc;
+        output_expression st ch e';
+        output_byte ch 0xFB;
+        output_byte ch 0x19;
+        output_byte ch ((if typ1.nullable then 1 else 0) + if typ2.nullable then 2 else 0);
+        output_uint ch i;
+        output_heaptype st.type_names ch typ1.typ;
+        output_heaptype st.type_names ch typ2.typ
+    | IfExpr (typ, e1, e2, e3) ->
+        output_expression st ch e1;
+        output_byte ch 0x04;
+        output_valtype st.type_names ch typ;
+        output_expression st ch e2;
+        output_byte ch 0x05;
+        output_expression st ch e3;
+        output_byte ch 0x0B
+
+  and output_instruction st ch i =
+    match i with
+    | Drop e ->
+        output_expression st ch e;
+        output_byte ch 0x1A
+    | Store _ | Store8 _ -> assert false
+    | LocalSet (i, e) ->
+        output_expression st ch e;
+        output_byte ch 0x21;
+        output_uint ch (Hashtbl.find st.current_local_names i)
+    | GlobalSet (g, e) ->
+        output_expression st ch e;
+        output_byte ch 0x24;
+        output_uint ch (Hashtbl.find st.global_names g)
+    | Loop (typ, l) ->
+        output_byte ch 0x03;
+        output_blocktype st.type_names ch typ;
+        List.iter ~f:(fun i' -> output_instruction st ch i') l;
+        output_byte ch 0x0B
+    | Block (typ, l) ->
+        output_byte ch 0x02;
+        output_blocktype st.type_names ch typ;
+        List.iter ~f:(fun i' -> output_instruction st ch i') l;
+        output_byte ch 0x0B
+    | If (typ, e, l1, l2) ->
+        output_expression st ch e;
+        output_byte ch 0x04;
+        output_blocktype st.type_names ch typ;
+        List.iter ~f:(fun i' -> output_instruction st ch i') l1;
+        if not (List.is_empty l2)
+        then (
+          output_byte ch 0x05;
+          List.iter ~f:(fun i' -> output_instruction st ch i') l2);
+        output_byte ch 0x0B
+    | Br_table (e, l, i) ->
+        output_expression st ch e;
+        output_byte ch 0x0E;
+        output_vec output_uint ch l;
+        output_uint ch i
+    | Br (i, None) ->
+        output_byte ch 0x0C;
+        output_uint ch i
+    | Br (i, Some e) ->
+        output_expression st ch e;
+        output_byte ch 0x0C;
+        output_uint ch i
+    | Br_if (i, e) ->
+        output_expression st ch e;
+        output_byte ch 0x0D;
+        output_uint ch i
+    | Return None -> output_byte ch 0x0F
+    | Return (Some e) ->
+        output_expression st ch e;
+        output_byte ch 0x0F
+    | CallInstr (f, l) ->
+        List.iter ~f:(fun e -> output_expression st ch e) l;
+        output_byte ch 0x10;
+        output_uint ch (Hashtbl.find st.func_names f)
+    | Nop -> ()
+    | Push e -> output_expression st ch e
+    | Try (typ, l, catches, catchall) ->
+        Feature.require exception_handling;
+        output_byte ch 0x06;
+        output_blocktype st.type_names ch typ;
+        List.iter ~f:(fun i' -> output_instruction st ch i') l;
+        List.iter
+          ~f:(fun (tag, l) ->
+            output_byte ch 0x07;
+            output_uint ch (Hashtbl.find st.tag_names tag);
+            List.iter ~f:(fun i' -> output_instruction st ch i') l)
+          catches;
+        (match catchall with
+        | Some l ->
+            output_byte ch 0x05;
+            List.iter ~f:(fun i' -> output_instruction st ch i') l
+        | None -> ());
+        output_byte ch 0X0B
+    | Throw (tag, e) ->
+        Feature.require exception_handling;
+        output_expression st ch e;
+        output_byte ch 0x08;
+        output_uint ch (Hashtbl.find st.tag_names tag)
+    | Rethrow i ->
+        Feature.require exception_handling;
+        output_byte ch 0x09;
+        output_uint ch i
+    | ArraySet (typ, e1, e2, e3) ->
+        Feature.require gc;
+        output_expression st ch e1;
+        output_expression st ch e2;
+        output_expression st ch e3;
+        output_byte ch 0xFB;
+        output_byte ch 0x0E;
+        output_uint ch (Hashtbl.find st.type_names typ)
+    | StructSet (typ, idx, e1, e2) ->
+        Feature.require gc;
+        output_expression st ch e1;
+        output_expression st ch e2;
+        output_byte ch 0xFB;
+        output_byte ch 0x05;
+        output_uint ch (Hashtbl.find st.type_names typ);
+        output_uint ch idx
+    | Return_call_indirect _ -> assert false
+    | Return_call (f, l) ->
+        Feature.require tail_call;
+        List.iter ~f:(fun e -> output_expression st ch e) l;
+        output_byte ch 0x12;
+        output_uint ch (Hashtbl.find st.func_names f)
+    | Return_call_ref (typ, e', l) ->
+        Feature.require tail_call;
+        List.iter ~f:(fun e' -> output_expression st ch e') l;
+        output_expression st ch e';
+        output_byte ch 0x15;
+        output_uint ch (Hashtbl.find st.type_names typ)
+    | Location (_, i') -> output_instruction st ch i'
+
+  let output_globals ch (st, global_idx, fields) =
+    let count =
+      List.fold_left
+        ~f:(fun count field ->
+          match field with
+          | Global _ -> count + 1
+          | Function _ | Type _ | Import _ | Data _ | Tag _ -> count)
+        ~init:0
+        fields
+    in
+    output_uint ch count;
+    let _idx =
+      List.fold_left
+        ~f:(fun idx field ->
+          match field with
+          | Global { name; typ; init; _ } ->
+              Hashtbl.add st.global_names name idx;
+              output_globaltype st.type_names ch typ;
+              output_expression st ch init;
+              output_byte ch 0x0B;
+              idx + 1
+          | Function _ | Type _ | Import _ | Data _ | Tag _ -> idx)
+        ~init:global_idx
+        fields
+    in
+    ()
+
+  let output_exports ch (func_names, global_names, fields) =
+    let count =
+      List.fold_left
+        ~f:(fun count field ->
+          match field with
+          | Function { exported_name = Some _; _ } | Global { exported_name = Some _; _ }
+            -> count + 1
+          | Function { exported_name = None; _ }
+          | Global { exported_name = None; _ }
+          | Import _ | Type _ | Data _ | Tag _ -> count)
+        ~init:0
+        fields
+    in
+    output_uint ch count;
+    List.iter
+      ~f:(fun field ->
+        match field with
+        | Function { exported_name = None; _ }
+        | Type _ | Data _
+        | Global { exported_name = None; _ }
+        | Tag _ | Import _ -> ()
+        | Function { name; exported_name = Some exported_name; _ } ->
+            output_name ch exported_name;
+            output_byte ch 0x00;
+            output_uint ch (Hashtbl.find func_names name)
+        | Global { name; exported_name = Some exported_name; typ; _ } ->
+            if typ.mut then Feature.require mutable_globals;
+            output_name ch exported_name;
+            output_byte ch 0x03;
+            output_uint ch (Hashtbl.find global_names name))
+      fields
+
+  let compute_data_names fields =
+    let data_count =
+      List.fold_left
+        ~f:(fun count field ->
+          match field with
+          | Data _ -> count + 1
+          | Function _ | Type _ | Import _ | Global _ | Tag _ -> count)
+        ~init:0
+        fields
+    in
+    let data_names = Hashtbl.create 16 in
+    let _idx =
+      List.fold_left
+        ~f:(fun idx field ->
+          match field with
+          | Data { name; _ } ->
+              Hashtbl.add data_names name idx;
+              idx + 1
+          | Function _ | Type _ | Import _ | Global _ | Tag _ -> idx)
+        ~init:0
+        fields
+    in
+    data_count, data_names
+
+  let data_contents contents =
+    let b = Buffer.create 16 in
+    List.iter
+      ~f:(fun d ->
+        match d with
+        | DataI8 c -> Buffer.add_uint8 b c
+        | DataI32 i -> Buffer.add_int32_le b i
+        | DataI64 i -> Buffer.add_int64_le b i
+        | DataBytes s -> Buffer.add_string b s
+        | DataSym _ -> assert false
+        | DataSpace n -> Buffer.add_string b (String.make n '\000'))
+      contents;
+    Buffer.contents b
+
+  let output_data_count ch data_count = output_uint ch data_count
+
+  let output_data ch (data_count, fields) =
+    output_uint ch data_count;
+    ignore
+      (List.fold_left
+         ~f:(fun idx field ->
+           match field with
+           | Data { active; contents; _ } ->
+               assert (not active);
+               output_byte ch 1;
+               output_name ch (data_contents contents);
+               idx + 1
+           | Function _ | Type _ | Import _ | Global _ | Tag _ -> idx)
+         ~init:0
+         fields)
+
+  let rec expr_function_references e set =
+    match e with
+    | Const _ | LocalGet _ | GlobalGet _ | Pop _ | RefNull _ -> set
+    | UnOp (_, e')
+    | I32WrapI64 e'
+    | I64ExtendI32 (_, e')
+    | F32DemoteF64 e'
+    | F64PromoteF32 e'
+    | LocalTee (_, e')
+    | RefI31 e'
+    | I31Get (_, e')
+    | ArrayLen e'
+    | StructGet (_, _, _, e')
+    | RefCast (_, e')
+    | RefTest (_, e')
+    | Br_on_cast (_, _, _, e')
+    | Br_on_cast_fail (_, _, _, e') -> expr_function_references e' set
+    | BinOp (_, e', e'')
+    | ArrayNew (_, e', e'')
+    | ArrayNewData (_, _, e', e'')
+    | ArrayGet (_, _, e', e'')
+    | RefEq (e', e'') ->
+        set |> expr_function_references e' |> expr_function_references e''
+    | Call_indirect _ | ConstSym _ | Load _ | Load8 _ | MemoryGrow _ -> assert false
+    | IfExpr (_, e1, e2, e3) ->
+        set
+        |> expr_function_references e1
+        |> expr_function_references e2
+        |> expr_function_references e3
+    | BlockExpr (_, l) ->
+        List.fold_left ~f:(fun set i -> instr_function_references i set) ~init:set l
+    | Call (_, l) | ArrayNewFixed (_, l) | StructNew (_, l) ->
+        List.fold_left ~f:(fun set i -> expr_function_references i set) ~init:set l
+    | Seq _ -> assert false
+    | RefFunc f -> Code.Var.Set.add f set
+    | Call_ref (_, e', l) ->
+        List.fold_left
+          ~f:(fun set i -> expr_function_references i set)
+          ~init:(expr_function_references e' set)
+          l
+
+  and instr_function_references i set =
+    match i with
+    | Drop e
+    | LocalSet (_, e)
+    | GlobalSet (_, e)
+    | Br (_, Some e)
+    | Br_table (e, _, _)
+    | Br_if (_, e)
+    | Return (Some e)
+    | Push e
+    | Throw (_, e) -> expr_function_references e set
+    | Store _ | Store8 _ -> assert false
+    | Loop (_, l) | Block (_, l) ->
+        List.fold_left ~f:(fun set i -> instr_function_references i set) ~init:set l
+    | If (_, e, l1, l2) ->
+        set
+        |> expr_function_references e
+        |> (fun init ->
+             List.fold_left ~f:(fun set i -> instr_function_references i set) ~init l1)
+        |> fun init ->
+        List.fold_left ~f:(fun set i -> instr_function_references i set) ~init l2
+    | Br (_, None) | Return None | Nop | Rethrow _ -> set
+    | CallInstr (_, l) ->
+        List.fold_left ~f:(fun set i -> expr_function_references i set) ~init:set l
+    | Try (_, l, catches, catchall) ->
+        List.fold_left ~f:(fun set i -> instr_function_references i set) ~init:set l
+        |> (fun init ->
+             List.fold_left
+               ~f:(fun set (_, l) ->
+                 List.fold_left
+                   ~f:(fun set i -> instr_function_references i set)
+                   ~init:set
+                   l)
+               ~init
+               catches)
+        |> fun init ->
+        List.fold_left
+          ~f:(fun set i -> instr_function_references i set)
+          ~init
+          (match catchall with
+          | Some l -> l
+          | None -> [])
+    | ArraySet (_, e1, e2, e3) ->
+        set
+        |> expr_function_references e1
+        |> expr_function_references e2
+        |> expr_function_references e3
+    | StructSet (_, _, e1, e2) ->
+        set |> expr_function_references e1 |> expr_function_references e2
+    | Return_call_indirect _ -> assert false
+    | Return_call (_, l) ->
+        List.fold_left ~f:(fun set i -> expr_function_references i set) ~init:set l
+    | Return_call_ref (_, e', l) ->
+        List.fold_left
+          ~f:(fun set i -> expr_function_references i set)
+          ~init:(expr_function_references e' set)
+          l
+    | Location (_, i') -> instr_function_references i' set
+
+  let function_references fields set =
+    List.fold_left
+      ~f:(fun set field ->
+        match field with
+        | Function { body; _ } ->
+            List.fold_left
+              ~f:(fun set i -> instr_function_references i set)
+              ~init:set
+              body
+        | Global _ | Import _ | Type _ | Data _ | Tag _ -> set)
+      ~init:set
+      fields
+
+  let output_elem ch (st, refs) =
+    output_byte ch (* declare *) 1;
+    output_byte ch (* func *) 3;
+    output_byte ch 0x00;
+    let refs = Code.Var.Set.elements refs in
+    output_vec (fun ch f -> output_uint ch (Hashtbl.find st.func_names f)) ch refs
+
+  let coalesce_locals l =
+    let rec loop acc n t l =
+      match l with
+      | [] -> List.rev ((n, t) :: acc)
+      | (_, t') :: r ->
+          if Poly.equal t t' then loop acc (n + 1) t r else loop ((n, t) :: acc) 1 t' r
+    in
+    match l with
+    | [] -> []
+    | (_, t) :: rem -> loop [] 1 t rem
+
+  let output_code ch (st, fields) =
+    let l =
+      List.fold_left
+        ~f:(fun acc field ->
+          match field with
+          | Function { name; param_names; locals; body; _ } ->
+              (name, param_names, locals, body) :: acc
+          | Type _ | Import _ | Data _ | Global _ | Tag _ -> acc)
+        ~init:[]
+        fields
+    in
+    output_vec
+      (with_size (fun ch (name, param_names, locals, body) ->
+           let current_local_names = Hashtbl.create 8 in
+           let idx =
+             List.fold_left
+               ~f:(fun idx x ->
+                 Hashtbl.add current_local_names x idx;
+                 idx + 1)
+               ~init:0
+               param_names
+           in
+           let _ =
+             List.fold_left
+               ~f:(fun idx (x, _) ->
+                 Hashtbl.add current_local_names x idx;
+                 idx + 1)
+               ~init:idx
+               locals
+           in
+           Hashtbl.add st.local_names name current_local_names;
+           let st = { st with current_local_names } in
+           output_vec
+             (fun ch (n, typ) ->
+               output_uint ch n;
+               output_valtype st.type_names ch typ)
+             ch
+             (coalesce_locals locals);
+           (try List.iter ~f:(fun i -> output_instruction st ch i) body
+            with e ->
+              let backtrace = Printexc.get_backtrace () in
+              prerr_endline (Printexc.to_string e);
+              prerr_endline backtrace;
+              assert false);
+           output_byte ch 0x0B))
+      ch
+      (List.rev l)
+
+  let output_section id f ch x =
+    output_byte ch id;
+    with_size f ch x
+
+  let rec find_available_name used name i =
+    let nm = Printf.sprintf "%s$%d" name i in
+    if StringSet.mem nm used then find_available_name used name (i + 1) else nm
+
+  let assign_names f tbl =
+    let names = Hashtbl.fold (fun name idx rem -> (idx, name) :: rem) tbl [] in
+    let names = List.sort ~cmp:(fun (idx, _) (idx', _) -> compare idx idx') names in
+    let used = ref StringSet.empty in
+    let names =
+      List.map
+        ~f:(fun (idx, x) ->
+          match f x with
+          | None -> idx, None
+          | Some nm ->
+              let nm =
+                if StringSet.mem nm !used then find_available_name !used nm 1 else nm
+              in
+              used := StringSet.add nm !used;
+              idx, Some nm)
+        names
+    in
+    let printer = Var_printer.create Var_printer.Alphabet.javascript in
+    let i = ref 0 in
+    let rec first_available_name () =
+      let nm = Var_printer.to_string printer !i in
+      incr i;
+      if StringSet.mem nm !used then first_available_name () else nm
+    in
+    List.map
+      ~f:(fun (idx, nm) ->
+        match nm with
+        | Some nm -> idx, nm
+        | None -> idx, first_available_name ())
+      names
+
+  let output_names ch st =
+    output_name ch "name";
+    let index = Code.Var.get_name in
+    let symbol name =
+      match name with
+      | V name -> Code.Var.get_name name
+      | S name -> Some name
+    in
+    let out id f tbl =
+      let names = assign_names f tbl in
+      if not (List.is_empty names)
+      then
+        output_section
+          id
+          (output_vec (fun ch (idx, name) ->
+               output_uint ch idx;
+               output_name ch name))
+          ch
+          names
+    in
+    let locals =
+      Hashtbl.fold
+        (fun name tbl rem -> (Hashtbl.find st.func_names name, tbl) :: rem)
+        st.local_names
+        []
+      |> List.sort ~cmp:(fun (idx, _) (idx', _) -> compare idx idx')
+    in
+    out 1 index st.func_names;
+    output_section
+      2
+      (output_vec (fun ch (idx, tbl) ->
+           output_uint ch idx;
+           let locals = assign_names index tbl in
+           output_vec
+             (fun ch (idx, name) ->
+               output_uint ch idx;
+               output_name ch name)
+             ch
+             locals))
+      ch
+      locals;
+    out 4 index st.type_names;
+    out 7 symbol st.global_names;
+    out 9 index st.data_names;
+    out 11 index st.tag_names
+
+  let output_features ch () =
+    output_name ch "target_features";
+    output_vec
+      (fun ch f ->
+        output_byte ch 0x2b;
+        output_name ch f)
+      ch
+      (Feature.get features)
+
+  let output_module ch fields =
+    output_string ch "\x00\x61\x73\x6D\x01\x00\x00\x00";
+    let func_types, type_names = output_section 1 output_types ch fields in
+    let func_idx, func_names, global_idx, global_names, _, tag_names =
+      output_section 2 output_imports ch (func_types, type_names, fields)
+    in
+    output_section 3 output_functions ch (func_idx, func_names, func_types, fields);
+    let st =
+      { type_names
+      ; func_names
+      ; global_names
+      ; data_names = Hashtbl.create 1
+      ; tag_names
+      ; local_names = Hashtbl.create 8
+      ; current_local_names = Hashtbl.create 8
+      }
+    in
+    output_section 6 output_globals ch (st, global_idx, fields);
+    output_section 7 output_exports ch (func_names, global_names, fields);
+    let refs = function_references fields Code.Var.Set.empty in
+    output_section 9 output_elem ch (st, refs);
+    let data_count, data_names = compute_data_names fields in
+    if data_count > 0
+    then (
+      Feature.require bulk_memory;
+      output_section 12 output_data_count ch data_count);
+    let st = { st with data_names } in
+    output_section 10 output_code ch (st, fields);
+    output_section 11 output_data ch (data_count, fields);
+    if Config.Flag.pretty () then output_section 0 output_names ch st;
+    if Feature.test gc then Feature.require reference_types;
+    output_section 0 output_features ch ()
+end
+
+let f ch fields =
+  let module O = Make (struct
+    type t = out_channel
+
+    let position = pos_out
+
+    let seek = seek_out
+
+    let byte = output_byte
+
+    let string = output_string
+  end) in
+  Code.Var.set_pretty true;
+  Code.Var.set_stable (Config.Flag.stable_var ());
+  O.output_module ch fields

--- a/compiler/lib/wasm/wa_wasm_output.mli
+++ b/compiler/lib/wasm/wa_wasm_output.mli
@@ -1,0 +1,1 @@
+val f : out_channel -> Wa_ast.module_field list -> unit


### PR DESCRIPTION
- A single wasm file is generated for each cma archive, which avoid having to load too many module.
- Support linking wasmo files into one wasma file. One can do:
   ```
   wasm_of_ocaml a.cmo
   wasm_of_ocaml b.cmo
   wasm_of_ocaml link -a -o foo.wasma a.wasmo b.wasmo
   ```
   instead of:
   ```
   ocamlc -a foo.cma a.cmo b.cmo
   wasm_of_ocaml link -o foo.wasma foo.cma
   ```
  This allows to make separate compilation more fine-grained, only regenerating Wasml code for modified files.
  See https://github.com/ocaml/dune/pull/7389