### PR TITLE
Switch to Binaryen 118

### DIFF
--- a/.github/workflows/build-wasm_of_ocaml.yml
+++ b/.github/workflows/build-wasm_of_ocaml.yml
@@ -31,14 +31,14 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: v22.0.0-v8-canary2024030314ed92e804
+          node-version: 22
 
       - name: Restore cached binaryen
         id: cache-binaryen
         uses: actions/cache/restore@v4
         with:
           path: binaryen
-          key: ${{ runner.os }}-binaryen-version_117
+          key: ${{ runner.os }}-binaryen-version_118
 
       - name: Checkout binaryen
         if: steps.cache-binaryen.outputs.cache-hit != 'true'
@@ -47,7 +47,7 @@ jobs:
           repository: WebAssembly/binaryen
           path: binaryen
           submodules: true
-          ref: version_117
+          ref: version_118
 
       - name: Install ninja
         if: steps.cache-binaryen.outputs.cache-hit != 'true'
@@ -65,7 +65,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: binaryen
-          key: ${{ runner.os }}-binaryen-version_117
+          key: ${{ runner.os }}-binaryen-version_118
 
       - name: Set binaryen's path
         run: |

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Wasm_of_ocaml is a fork of Js_of_ocaml which compiles OCaml bytecode to WebAssem
 
 ## Requirements
 
-Wasm_of_ocaml relies on the Binaryen toolchain; currently, only [version 117](https://github.com/WebAssembly/binaryen/releases/tag/version_117) is supported. Binaryen commands must be in the PATH for wasm_of_ocaml to function.
+Wasm_of_ocaml relies on the Binaryen toolchain; currently, only versions [118](https://github.com/WebAssembly/binaryen/releases/tag/version_118) or greater are supported. Binaryen commands must be in the PATH for wasm_of_ocaml to function.
 
 ## Supported engines
 
-The generated code works with Chrome 11.9, [node V8 canary](https://nodejs.org/download/v8-canary/v21.0.0-v8-canary20230927fa59f85d60/) and [Firefox 122](https://www.mozilla.org/en-US/firefox/new/).
+The generated code works with Chrome 11.9, Node.js 22 and Firefox 122 (or more recent versions of these applications).
 
 In particular, the output code requires the following [Wasm extensions](https://webassembly.org/roadmap/) to run:
 - [the GC extension](https://github.com/WebAssembly/gc), including functional references and 31-bit integers

--- a/runtime/wasm/dune
+++ b/runtime/wasm/dune
@@ -13,7 +13,7 @@
    (system
     "which wasm-merge > /dev/null || (echo 'Error: Binaryen tools not found in the PATH'; false)")
    (system
-    "wasm-merge --version | grep -q 'version 117' || (echo 'Error: Binaryen version 117 is currently required'; false)")
+    "wasm-merge --version | grep -q 'version \\(11[789]\\|1[2-9][0-9]\\)' || (echo 'Error: Binaryen version 117 or greater is currently required'; false)")
    (pipe-stdout
     (run
      wasm-merge


### PR DESCRIPTION
This allows us to use a stable version of Node.js.