### PR TITLE
Effects: make continuation format compatible with OCaml 5.2

### DIFF
--- a/runtime/wasm/obj.wat
+++ b/runtime/wasm/obj.wat
@@ -87,7 +87,7 @@
             (field (mut (ref null $cps_closure))))))
 
    (global $forcing_tag i32 (i32.const 244))
-   (global $cont_tag i32 (i32.const 245))
+   (global $cont_tag (export "cont_tag") i32 (i32.const 245))
    (global $lazy_tag (export "lazy_tag") i32 (i32.const 246))
    (global $closure_tag i32 (i32.const 247))
    (global $object_tag (export "object_tag") i32 (i32.const 248))


### PR DESCRIPTION
With https://github.com/ocaml/ocaml/pull/12735, continuations should be implemented as a block with at least two fields.
We should port the optimization in that PR at some point to Js_of_ocaml and Wasm_of_ocaml.