### PR TITLE
Rename `cps_calls` into `trampolined_calls` for clarity

### DIFF
--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -95,7 +95,10 @@ let effects p =
   then (
     if debug () then Format.eprintf "Effects...@.";
     p |> Deadcode.f +> Effects.f +> map_fst Lambda_lifting.f)
-  else p, (Code.Var.Set.empty : Effects.cps_calls), (Code.Var.Set.empty : Effects.in_cps)
+  else
+    ( p
+    , (Code.Var.Set.empty : Effects.trampolined_calls)
+    , (Code.Var.Set.empty : Effects.in_cps) )
 
 let exact_calls profile p =
   if not (Config.Flag.effects ())
@@ -179,14 +182,14 @@ let generate
     ~exported_runtime
     ~wrap_with_fun
     ~warn_on_unhandled_effect
-    ((p, live_vars), cps_calls, _) =
+    ((p, live_vars), trampolined_calls, _) =
   if times () then Format.eprintf "Start Generation...@.";
   let should_export = should_export wrap_with_fun in
   Generate.f
     p
     ~exported_runtime
     ~live_vars
-    ~cps_calls
+    ~trampolined_calls
     ~should_export
     ~warn_on_unhandled_effect
     d

--- a/compiler/lib/effects.mli
+++ b/compiler/lib/effects.mli
@@ -16,8 +16,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-type cps_calls = Code.Var.Set.t
+type trampolined_calls = Code.Var.Set.t
 
 type in_cps = Code.Var.Set.t
 
-val f : Code.program * Deadcode.variable_uses -> Code.program * cps_calls * in_cps
+val f : Code.program * Deadcode.variable_uses -> Code.program * trampolined_calls * in_cps

--- a/compiler/lib/generate.mli
+++ b/compiler/lib/generate.mli
@@ -22,7 +22,7 @@ val f :
      Code.program
   -> exported_runtime:bool
   -> live_vars:Deadcode.variable_uses
-  -> cps_calls:Effects.cps_calls
+  -> trampolined_calls:Effects.trampolined_calls
   -> should_export:bool
   -> warn_on_unhandled_effect:bool
   -> Parse_bytecode.Debug.t


### PR DESCRIPTION
This makes the code clearer and will be helpful when rebasing ocsigen/js_of_ocaml#1461 after the merge of JSOO and WSOO.