### PR TITLE
Only link `jslib_js_of_ocaml` from the JavaScript runtime

### DIFF
--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -254,12 +254,10 @@ let run
       let filename = Builtins.File.name t in
       let runtimes = Linker.Fragment.parse_builtin t in
       Linker.load_fragments
-        ~ignore_always_annotation:true
         ~target_env:Target_env.Isomorphic
         ~filename
         runtimes);
   Linker.load_files
-    ~ignore_always_annotation:true
     ~target_env:Target_env.Isomorphic
     runtime_js_files;
   Linker.check_deps ();

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -249,7 +249,7 @@ let run
         | None -> `Fst name)
   in
   let t1 = Timer.make () in
-  let builtin = Js_of_ocaml_compiler_runtime_files.runtime @ builtin in
+  let builtin = [Js_of_ocaml_compiler_runtime_files.jslib_js_of_ocaml] @ builtin in
   List.iter builtin ~f:(fun t ->
       let filename = Builtins.File.name t in
       let runtimes = Linker.Fragment.parse_builtin t in

--- a/compiler/lib/linker.ml
+++ b/compiler/lib/linker.ml
@@ -437,7 +437,7 @@ let list_all ?from () =
     provided
     StringSet.empty
 
-let load_fragment ~ignore_always_annotation ~target_env ~filename (f : Fragment.t) =
+let load_fragment ~target_env ~filename (f : Fragment.t) =
   match f with
   | Always_include code ->
       always_included :=
@@ -482,8 +482,6 @@ let load_fragment ~ignore_always_annotation ~target_env ~filename (f : Fragment.
                 filename;
             if always
             then (
-              if not ignore_always_annotation
-              then
                 always_included :=
                   { ar_filename = filename; ar_program = code; ar_requires = requires }
                   :: !always_included;
@@ -588,24 +586,24 @@ let check_deps () =
           ())
     code_pieces
 
-let load_file ~ignore_always_annotation ~target_env filename =
+let load_file ~target_env filename =
   List.iter (Fragment.parse_file filename) ~f:(fun frag ->
       let (`Ok | `Ignored) =
-        load_fragment ~ignore_always_annotation ~target_env ~filename frag
+        load_fragment ~target_env ~filename frag
       in
       ())
 
-let load_fragments ?(ignore_always_annotation = false) ~target_env ~filename l =
+let load_fragments ~target_env ~filename l =
   List.iter l ~f:(fun frag ->
       let (`Ok | `Ignored) =
-        load_fragment ~ignore_always_annotation ~target_env ~filename frag
+        load_fragment ~target_env ~filename frag
       in
       ());
   check_deps ()
 
-let load_files ?(ignore_always_annotation = false) ~target_env l =
+let load_files ~target_env l =
   List.iter l ~f:(fun filename ->
-      load_file ~ignore_always_annotation ~target_env filename);
+      load_file ~target_env filename);
   check_deps ()
 
 (* resolve *)

--- a/compiler/lib/linker.mli
+++ b/compiler/lib/linker.mli
@@ -37,11 +37,10 @@ end
 val reset : unit -> unit
 
 val load_files :
-  ?ignore_always_annotation:bool -> target_env:Target_env.t -> string list -> unit
+  target_env:Target_env.t -> string list -> unit
 
 val load_fragments :
-     ?ignore_always_annotation:bool
-  -> target_env:Target_env.t
+  target_env:Target_env.t
   -> filename:string
   -> Fragment.t list
   -> unit


### PR DESCRIPTION
And no longer ignore the always annotation, since this was only needed for `sys.js`.