### PR TITLE
Update outdated info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,7 @@ wasm_of_ocaml _build/default/bin/web/index.bc-for-jsoo
 
 ## Implementation status
 
-A large part of the runtime is [implemented](https://github.com/ocaml-wasm/wasm_of_ocaml/issues/5). File-related functions and dynamic linking are not supported yet.
-
-Separate compilation is not implemented yet.
+A large part of the runtime is [implemented](https://github.com/ocaml-wasm/wasm_of_ocaml/issues/5). File-related functions are not supported yet.
 
 ## Compatibility with Js_of_ocaml
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ wasm_of_ocaml _build/default/bin/web/index.bc-for-jsoo
 
 ## Implementation status
 
-A large part of the runtime is [implemented](https://github.com/ocaml-wasm/wasm_of_ocaml/issues/5). File-related functions are not supported yet.
+A large part of the runtime is [implemented](https://github.com/ocaml-wasm/wasm_of_ocaml/issues/5). File-related functions and dynamic linking are not supported yet.
 
 ## Compatibility with Js_of_ocaml
 


### PR DESCRIPTION
Separate compilation is now supported, as well as dynlink (I think?).