### PR TITLE
Link the whole JavaScript runtime again

### DIFF
--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -270,8 +270,15 @@ let run
   List.iter builtin ~f:(fun t ->
       let filename = Builtins.File.name t in
       let runtimes = Linker.Fragment.parse_builtin t in
-      Linker.load_fragments ~target_env:Target_env.Isomorphic ~filename runtimes);
-  Linker.load_files ~target_env:Target_env.Isomorphic runtime_js_files;
+      Linker.load_fragments
+        ~ignore_always_annotation:true
+        ~target_env:Target_env.Isomorphic
+        ~filename
+        runtimes);
+  Linker.load_files
+    ~ignore_always_annotation:true
+    ~target_env:Target_env.Isomorphic
+    runtime_js_files;
   Linker.check_deps ();
   if times () then Format.eprintf "  parsing js: %a@." Timer.print t1;
   if times () then Format.eprintf "Start parsing...@.";

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -266,7 +266,7 @@ let run
         | None -> `Fst name)
   in
   let t1 = Timer.make () in
-  let builtin = [ Js_of_ocaml_compiler_runtime_files.jslib_js_of_ocaml ] @ builtin in
+  let builtin = Js_of_ocaml_compiler_runtime_files.runtime @ builtin in
   List.iter builtin ~f:(fun t ->
       let filename = Builtins.File.name t in
       let runtimes = Linker.Fragment.parse_builtin t in

--- a/compiler/lib/linker.ml
+++ b/compiler/lib/linker.ml
@@ -437,7 +437,7 @@ let list_all ?from () =
     provided
     StringSet.empty
 
-let load_fragment ~target_env ~filename (f : Fragment.t) =
+let load_fragment ~ignore_always_annotation ~target_env ~filename (f : Fragment.t) =
   match f with
   | Always_include code ->
       always_included :=
@@ -482,9 +482,11 @@ let load_fragment ~target_env ~filename (f : Fragment.t) =
                 filename;
             if always
             then (
-              always_included :=
-                { ar_filename = filename; ar_program = code; ar_requires = requires }
-                :: !always_included;
+              if not ignore_always_annotation
+              then
+                always_included :=
+                  { ar_filename = filename; ar_program = code; ar_requires = requires }
+                  :: !always_included;
               `Ok)
             else
               error
@@ -586,19 +588,24 @@ let check_deps () =
           ())
     code_pieces
 
-let load_file ~target_env filename =
+let load_file ~ignore_always_annotation ~target_env filename =
   List.iter (Fragment.parse_file filename) ~f:(fun frag ->
-      let (`Ok | `Ignored) = load_fragment ~target_env ~filename frag in
+      let (`Ok | `Ignored) =
+        load_fragment ~ignore_always_annotation ~target_env ~filename frag
+      in
       ())
 
-let load_fragments ~target_env ~filename l =
+let load_fragments ?(ignore_always_annotation = false) ~target_env ~filename l =
   List.iter l ~f:(fun frag ->
-      let (`Ok | `Ignored) = load_fragment ~target_env ~filename frag in
+      let (`Ok | `Ignored) =
+        load_fragment ~ignore_always_annotation ~target_env ~filename frag
+      in
       ());
   check_deps ()
 
-let load_files ~target_env l =
-  List.iter l ~f:(fun filename -> load_file ~target_env filename);
+let load_files ?(ignore_always_annotation = false) ~target_env l =
+  List.iter l ~f:(fun filename ->
+      load_file ~ignore_always_annotation ~target_env filename);
   check_deps ()
 
 (* resolve *)

--- a/compiler/lib/linker.mli
+++ b/compiler/lib/linker.mli
@@ -36,9 +36,15 @@ end
 
 val reset : unit -> unit
 
-val load_files : target_env:Target_env.t -> string list -> unit
+val load_files :
+  ?ignore_always_annotation:bool -> target_env:Target_env.t -> string list -> unit
 
-val load_fragments : target_env:Target_env.t -> filename:string -> Fragment.t list -> unit
+val load_fragments :
+     ?ignore_always_annotation:bool
+  -> target_env:Target_env.t
+  -> filename:string
+  -> Fragment.t list
+  -> unit
 
 val check_deps : unit -> unit
 


### PR DESCRIPTION
We need it to get the primitive annotations.
This reverts #72. We will eventually use ocsigen/js_of_ocaml#1674. 