### PR TITLE
Workaround for the local variable limits of binaryen's binary parser

### DIFF
--- a/compiler/lib/wasm/wa_binaryen.mli
+++ b/compiler/lib/wasm/wa_binaryen.mli
@@ -18,7 +18,7 @@
 
 val link :
      runtime_files:string list
-  -> input_files:string list
+  -> input_files:(string * string option) list
   -> opt_output_sourcemap:string option
   -> output_file:string
   -> unit
@@ -32,9 +32,11 @@ val dead_code_elimination :
   -> Stdlib.StringSet.t
 
 val optimize :
-     profile:Driver.profile option
+     ?profile:Driver.profile option
+  -> ?extra_options:string list
   -> opt_input_sourcemap:string option
   -> input_file:string
   -> opt_output_sourcemap:string option
   -> output_file:string
+  -> unit
   -> unit


### PR DESCRIPTION
Binaryen's binary parser currently enforces a limit of 50 000 locals per function (see WebAssembly/binaryen#6677). To avoid reaching this limit, this first compiles the generated code with wasm-opt with a limited number of optimization passes before calling wasm-merge. Otherwise, wasm-merge (which does not perform any optimization) can produce a binary with an overly large number of locals, that will be rejected by other binaryen tools.