### PR TITLE
Integrate "Target-specific code" (ocsigen/js_of_ocaml#1655)

### DIFF
--- a/compiler/bin-js_of_ocaml/build_fs.ml
+++ b/compiler/bin-js_of_ocaml/build_fs.ml
@@ -75,10 +75,10 @@ function jsoo_create_file_extern(name,content){
       let pfs_fmt = Pretty_print.to_out_channel chan in
       let (_ : Source_map.t option) =
         Driver.f
-          ~target:(JavaScript pfs_fmt)
           ~standalone:true
           ~wrap_with_fun:`Iife
           ~link:`Needed
+          ~formatter:pfs_fmt
           (Parse_bytecode.Debug.create ~include_cmis:false false)
           code
       in

--- a/compiler/bin-js_of_ocaml/check_runtime.ml
+++ b/compiler/bin-js_of_ocaml/check_runtime.ml
@@ -43,7 +43,8 @@ let print_groups output l =
               output_string output (Printf.sprintf "%s\n" name)))
 
 let f (runtime_files, bytecode, target_env) =
-  Generate.init ();
+  Config.set_target `JavaScript;
+  Linker.reset ();
   let runtime_files, builtin =
     List.partition_map runtime_files ~f:(fun name ->
         match Builtins.find name with

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -323,7 +323,6 @@ let run
          let linkall = linkall || toplevel || dynlink in
          let code =
            Parse_bytecode.from_exe
-             ~target:`JavaScript
              ~includes:include_dirs
              ~include_cmis
              ~link_info:(toplevel || dynlink)

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -91,6 +91,7 @@ let run
     } =
   let include_cmis = toplevel && not no_cmis in
   let custom_header = common.Jsoo_cmdline.Arg.custom_header in
+  Config.set_target `JavaScript;
   Jsoo_cmdline.Arg.eval common;
   Generate.init ();
   (match output_file with
@@ -184,7 +185,7 @@ let run
     let init_pseudo_fs = fs_external && standalone in
     let sm =
       match output_file with
-      | `Stdout, fmt ->
+      | `Stdout, formatter ->
           let instr =
             List.concat
               [ pseudo_fs_instr `create_file one.debug one.cmis
@@ -200,9 +201,10 @@ let run
             ~link
             ~wrap_with_fun
             ?source_map
+            ~formatter
             one.debug
             code
-      | `File, fmt ->
+      | `File, formatter ->
           let fs_instr1, fs_instr2 =
             match fs_output with
             | None -> pseudo_fs_instr `create_file one.debug one.cmis, []
@@ -224,6 +226,7 @@ let run
               ~link
               ~wrap_with_fun
               ?source_map
+              ~formatter
               one.debug
               code
           in

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -53,7 +53,7 @@ let output_gen ~standalone ~custom_header ~build_info ~source_map output_file f 
               let data = Source_map.to_string sm in
               "data:application/json;base64," ^ Base64.encode_exn data
           | Some output_file ->
-              Source_map.to_file sm ~file:output_file;
+              Source_map.to_file sm output_file;
               Filename.basename output_file
         in
         Pretty_print.newline fmt;

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -195,7 +195,6 @@ let run
           in
           let code = Code.prepend one.code instr in
           Driver.f
-            ~target:(JavaScript fmt)
             ~standalone
             ?profile
             ~link
@@ -220,7 +219,6 @@ let run
           let code = Code.prepend one.code instr in
           let res =
             Driver.f
-              ~target:(JavaScript fmt)
               ~standalone
               ?profile
               ~link
@@ -285,7 +283,7 @@ let run
    then (
      let prims = Linker.list_all () |> StringSet.elements in
      assert (List.length prims > 0);
-     let code, uinfo = Parse_bytecode.predefined_exceptions ~target:`JavaScript in
+     let code, uinfo = Parse_bytecode.predefined_exceptions () in
      let uinfo = { uinfo with primitives = uinfo.primitives @ prims } in
      let code : Parse_bytecode.one =
        { code
@@ -358,7 +356,6 @@ let run
          let t1 = Timer.make () in
          let code =
            Parse_bytecode.from_cmo
-             ~target:`JavaScript
              ~includes:include_dirs
              ~include_cmis
              ~debug:need_debug
@@ -415,7 +412,6 @@ let run
              let t1 = Timer.make () in
              let code =
                Parse_bytecode.from_cmo
-                 ~target:`JavaScript
                  ~includes:include_dirs
                  ~include_cmis
                  ~debug:need_debug
@@ -447,7 +443,6 @@ let run
                let t1 = Timer.make () in
                let code =
                  Parse_bytecode.from_cmo
-                   ~target:`JavaScript
                    ~includes:include_dirs
                    ~include_cmis
                    ~debug:need_debug

--- a/compiler/bin-js_of_ocaml/link.ml
+++ b/compiler/bin-js_of_ocaml/link.ml
@@ -150,6 +150,7 @@ let f
     ; mklib
     ; toplevel
     } =
+  Config.set_target `JavaScript;
   Jsoo_cmdline.Arg.eval common;
   let with_output f =
     match output_file with

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -141,7 +141,12 @@ let generate_prelude ~out_file =
   Filename.gen_file out_file
   @@ fun ch ->
   let code, uinfo = Parse_bytecode.predefined_exceptions () in
-  let Driver.{ program; variable_uses; in_cps; _ } = Driver.optimize code in
+  let profile =
+    match Driver.profile 1 with
+    | Some p -> p
+    | None -> assert false
+  in
+  let Driver.{ program; variable_uses; in_cps; _ } = Driver.optimize ~profile code in
   let context = Wa_generate.start () in
   let debug = Parse_bytecode.Debug.create ~include_cmis:false false in
   let _ =
@@ -294,7 +299,13 @@ let run
     check_debug one;
     let code = one.code in
     let standalone = Option.is_none unit_name in
-    let Driver.{ program; variable_uses; in_cps; _ } = Driver.optimize ?profile code in
+    let profile =
+      match profile, Driver.profile 1 with
+      | Some p, _ -> p
+      | None, Some p -> p
+      | None, None -> assert false
+    in
+    let Driver.{ program; variable_uses; in_cps; _ } = Driver.optimize ~profile code in
     let context = Wa_generate.start () in
     let debug = one.debug in
     let toplevel_name, generated_js =

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -391,7 +391,6 @@ let run
          let t1 = Timer.make () in
          let code =
            Parse_bytecode.from_exe
-             ~target:`Wasm
              ~includes:include_dirs
              ~include_cmis:false
              ~link_info:false

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -30,7 +30,7 @@ let update_sourcemap ~sourcemap_root ~sourcemap_don't_inline_content sourcemap_f
   if Option.is_some sourcemap_root || not sourcemap_don't_inline_content
   then (
     let open Source_map in
-    let source_map, mappings = Source_map.of_file_no_mappings sourcemap_file in
+    let source_map = Source_map.of_file sourcemap_file in
     assert (List.is_empty (Option.value source_map.sources_content ~default:[]));
     (* Add source file contents to source map *)
     let sources_content =
@@ -50,7 +50,7 @@ let update_sourcemap ~sourcemap_root ~sourcemap_don't_inline_content sourcemap_f
           (if Option.is_some sourcemap_root then sourcemap_root else source_map.sourceroot)
       }
     in
-    Source_map.to_file ?mappings source_map ~file:sourcemap_file)
+    Source_map.to_file source_map sourcemap_file)
 
 let opt_with action x f =
   match x with

--- a/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
+++ b/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
@@ -16,6 +16,9 @@ let split_primitives p =
 external get_section_table : unit -> (string * Obj.t) list = "caml_get_section_table"
 
 let () =
+  (match Sys.backend_type with
+  | Sys.Other "js_of_ocaml" -> Config.set_target `JavaScript
+  | Sys.(Native | Bytecode | Other _) -> failwith "Expected backend `js_of_ocaml`");
   let global = J.pure_js_expr "globalThis" in
   Config.Flag.set "use-js-string" (Jsoo_runtime.Sys.Config.use_js_string ());
   Config.Flag.set "effects" (Jsoo_runtime.Sys.Config.effects ());

--- a/compiler/lib-runtime-files/gen/gen.ml
+++ b/compiler/lib-runtime-files/gen/gen.ml
@@ -47,6 +47,7 @@ let rec list_product l =
 let bool = [ true; false ]
 
 let () =
+  Js_of_ocaml_compiler.Config.set_target `JavaScript;
   let () = set_binary_mode_out stdout true in
   match Array.to_list Sys.argv with
   | [] -> assert false

--- a/compiler/lib/code.ml
+++ b/compiler/lib/code.ml
@@ -284,10 +284,10 @@ type constant =
   | NativeString of Native_string.t
   | Float of float
   | Float_array of float array
-  | Int of int32
-  | Int32 of int32
-  | Int64 of int64
-  | NativeInt of nativeint
+  | Int of Int32.t
+  | Int32 of Int32.t
+  | Int64 of Int64.t
+  | NativeInt of Int32.t (* Native int are 32bit on all known backend *)
   | Tuple of int * constant array * array_or_not
 
 module Constant = struct
@@ -311,7 +311,7 @@ module Constant = struct
           !same
     | Int a, Int b | Int32 a, Int32 b -> Some (Int32.equal a b)
     | Int64 a, Int64 b -> Some (Int64.equal a b)
-    | NativeInt a, NativeInt b -> Some (Nativeint.equal a b)
+    | NativeInt a, NativeInt b -> Some (Int32.equal a b)
     | Float_array a, Float_array b -> Some (Array.equal Float.ieee_equal a b)
     | Float a, Float b -> Some (Float.ieee_equal a b)
     | String _, NativeString _ | NativeString _, String _ -> None
@@ -459,7 +459,7 @@ module Print = struct
     | Int i -> Format.fprintf f "%ld" i
     | Int32 i -> Format.fprintf f "%ldl" i
     | Int64 i -> Format.fprintf f "%LdL" i
-    | NativeInt i -> Format.fprintf f "%ndn" i
+    | NativeInt i -> Format.fprintf f "%ldn" i
     | Tuple (tag, a, _) -> (
         Format.fprintf f "<%d>" tag;
         match Array.length a with

--- a/compiler/lib/code.ml
+++ b/compiler/lib/code.ml
@@ -816,6 +816,7 @@ let with_invariant = Debug.find "invariant"
 let check_defs = false
 
 let invariant { blocks; start; _ } =
+  let target = Config.target () in
   if with_invariant ()
   then (
     assert (Addr.Map.mem start blocks);
@@ -830,6 +831,19 @@ let invariant { blocks; start; _ } =
         assert (not (Var.ISet.mem defs x));
         Var.ISet.add defs x)
     in
+    let check_constant = function
+      | NativeInt _ | Int32 _ ->
+          assert (
+            match target with
+            | `Wasm -> true
+            | _ -> false)
+      | String _ | NativeString _ | Float _ | Float_array _ | Int _ | Int64 _
+      | Tuple (_, _, _) -> ()
+    in
+    let check_prim_arg = function
+      | Pc c -> check_constant c
+      | Pv _ -> ()
+    in
     let check_expr = function
       | Apply _ -> ()
       | Block (_, _, _, _) -> ()
@@ -837,8 +851,8 @@ let invariant { blocks; start; _ } =
       | Closure (l, cont) ->
           List.iter l ~f:define;
           check_cont cont
-      | Constant _ -> ()
-      | Prim (_, _) -> ()
+      | Constant c -> check_constant c
+      | Prim (_, args) -> List.iter ~f:check_prim_arg args
       | Special _ -> ()
     in
     let check_instr (i, _loc) =

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -164,10 +164,10 @@ type constant =
   | NativeString of Native_string.t
   | Float of float
   | Float_array of float array
-  | Int of int32
-  | Int32 of int32  (** Only produced when compiling to WebAssembly. *)
-  | Int64 of int64
-  | NativeInt of nativeint  (** Only produced when compiling to WebAssembly. *)
+  | Int of Int32.t
+  | Int32 of Int32.t  (** Only produced when compiling to WebAssembly. *)
+  | Int64 of Int64.t
+  | NativeInt of Int32.t  (** Only produced when compiling to WebAssembly. *)
   | Tuple of int * constant array * array_or_not
 
 module Constant : sig

--- a/compiler/lib/config.ml
+++ b/compiler/lib/config.ml
@@ -162,7 +162,7 @@ module Param = struct
     p
       ~name:"tc"
       ~desc:"Set tailcall optimisation"
-      (enum [ "trampoline", TcTrampoline; (* default *) "none", TcNone ])
+      (enum [ "trampoline", TcTrampoline (* default *); "none", TcNone ])
 
   let lambda_lifting_threshold =
     (* When we reach this depth, we start looking for functions to be lifted *)
@@ -178,3 +178,15 @@ module Param = struct
       ~desc:"Set baseline for lifting deeply nested functions"
       (int 1)
 end
+
+(****)
+
+let target_ : [ `JavaScript | `Wasm | `None ] ref = ref `None
+
+let target () =
+  match !target_ with
+  | `None -> failwith "target was not set"
+  | (`JavaScript | `Wasm) as t -> t
+
+let set_target (t : [ `JavaScript | `Wasm ]) =
+  target_ := (t :> [ `JavaScript | `Wasm | `None ])

--- a/compiler/lib/config.mli
+++ b/compiler/lib/config.mli
@@ -78,6 +78,7 @@ module Flag : sig
   val disable : string -> unit
 end
 
+(** This module contains parameters that may be modified through command-line flags. *)
 module Param : sig
   val set : string -> string -> unit
 
@@ -102,3 +103,13 @@ module Param : sig
 
   val lambda_lifting_baseline : unit -> int
 end
+
+(****)
+
+(** {2 Parameters that are constant across a program run} *)
+
+(** These parameters should be set at most once at the beginning of the program. *)
+
+val target : unit -> [ `JavaScript | `Wasm ]
+
+val set_target : [ `JavaScript | `Wasm ] -> unit

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -23,6 +23,14 @@ let debug = Debug.find "main"
 
 let times = Debug.find "times"
 
+type optimized_result =
+  { program : Code.program
+  ; variable_uses : Deadcode.variable_uses
+  ; trampolined_calls : Effects.trampolined_calls
+  ; in_cps : Effects.in_cps
+  ; deadcode_sentinal : Code.Var.t
+  }
+
 type profile =
   | O1
   | O2
@@ -44,35 +52,35 @@ let deadcode p =
   let r, _ = deadcode' p in
   r
 
-let inline ~target p =
+let inline p =
   if Config.Flag.inline () && Config.Flag.deadcode ()
   then (
     let p, live_vars = deadcode' p in
     if debug () then Format.eprintf "Inlining...@.";
-    Inline.f ~target p live_vars)
+    Inline.f p live_vars)
   else p
 
 let specialize_1 (p, info) =
   if debug () then Format.eprintf "Specialize...@.";
   Specialize.f ~function_arity:(fun f -> Specialize.function_arity info f) p
 
-let specialize_js ~target (p, info) =
+let specialize_js (p, info) =
   if debug () then Format.eprintf "Specialize js...@.";
-  Specialize_js.f ~target info p
+  Specialize_js.f info p
 
 let specialize_js_once p =
   if debug () then Format.eprintf "Specialize js once...@.";
   Specialize_js.f_once p
 
-let specialize' ~target (p, info) =
+let specialize' (p, info) =
   let p = specialize_1 (p, info) in
-  let p = specialize_js ~target (p, info) in
+  let p = specialize_js (p, info) in
   p, info
 
-let specialize ~target p = fst (specialize' ~target p)
+let specialize p = fst (specialize' p)
 
-let eval ~target (p, info) =
-  if Config.Flag.staticeval () then Eval.f ~target info p else p
+let eval (p, info) =
+  if Config.Flag.staticeval () then Eval.f info p else p
 
 let flow p =
   if debug () then Format.eprintf "Data flow...@.";
@@ -128,53 +136,53 @@ let identity x = x
 
 (* o1 *)
 
-let o1 ~target : 'a -> 'a =
+let o1 : 'a -> 'a =
   print
   +> tailcall
   +> flow_simple (* flow simple to keep information for future tailcall opt *)
-  +> specialize' ~target
-  +> eval ~target
-  +> inline ~target (* inlining may reveal new tailcall opt *)
+  +> specialize'
+  +> eval
+  +> inline (* inlining may reveal new tailcall opt *)
   +> deadcode
   +> tailcall
   +> phi
   +> flow
-  +> specialize' ~target
-  +> eval ~target
-  +> inline ~target
+  +> specialize'
+  +> eval
+  +> inline
   +> deadcode
   +> print
   +> flow
-  +> specialize' ~target
-  +> eval ~target
-  +> inline ~target
+  +> specialize'
+  +> eval
+  +> inline
   +> deadcode
   +> phi
   +> flow
-  +> specialize ~target
+  +> specialize
   +> identity
 
 (* o2 *)
 
-let o2 ~target : 'a -> 'a = loop 10 "o1" (o1 ~target) 1 +> print
+let o2 : 'a -> 'a = loop 10 "o1" o1 1 +> print
 
 (* o3 *)
 
-let round1 ~target : 'a -> 'a =
+let round1 : 'a -> 'a =
   print
   +> tailcall
-  +> inline ~target (* inlining may reveal new tailcall opt *)
+  +> inline (* inlining may reveal new tailcall opt *)
   +> deadcode (* deadcode required before flow simple -> provided by constant *)
   +> flow_simple (* flow simple to keep information for future tailcall opt *)
-  +> specialize' ~target
-  +> eval ~target
+  +> specialize'
+  +> eval
   +> identity
 
-let round2 ~target = flow +> specialize' ~target +> eval ~target +> deadcode +> o1 ~target
+let round2 = flow +> specialize' +> eval +> deadcode +> o1
 
-let o3 ~target =
-  loop 10 "tailcall+inline" (round1 ~target) 1
-  +> loop 10 "flow" (round2 ~target) 1
+let o3 =
+  loop 10 "tailcall+inline" round1 1
+  +> loop 10 "flow" round2 1
   +> print
 
 let generate
@@ -182,13 +190,13 @@ let generate
     ~exported_runtime
     ~wrap_with_fun
     ~warn_on_unhandled_effect
-    ((p, live_vars), trampolined_calls, _) =
+    { program; variable_uses; trampolined_calls; deadcode_sentinal = _; in_cps = _ } =
   if times () then Format.eprintf "Start Generation...@.";
   let should_export = should_export wrap_with_fun in
   Generate.f
-    p
+    program
     ~exported_runtime
-    ~live_vars
+    ~live_vars:variable_uses
     ~trampolined_calls
     ~should_export
     ~warn_on_unhandled_effect
@@ -642,18 +650,7 @@ let configure formatter =
   Code.Var.set_pretty (pretty && not (Config.Flag.shortvar ()));
   Code.Var.set_stable (Config.Flag.stable_var ())
 
-type 'a target =
-  | JavaScript : Pretty_print.t -> Source_map.t option target
-  | Wasm
-      : (Deadcode.variable_uses * Effects.in_cps * Code.program * Parse_bytecode.Debug.t)
-        target
-
-let target_flag (type a) (t : a target) =
-  match t with
-  | JavaScript _ -> `JavaScript
-  | Wasm -> `Wasm
-
-let link_and_pack ?(standalone = true) ?(wrap_with_fun = `Iife) ~link p =
+let link_and_pack ?(standalone = true) ?(wrap_with_fun = `Iife) ?(link = `No) p =
   let export_runtime =
     match link with
     | `All | `All_from _ -> true
@@ -665,73 +662,57 @@ let link_and_pack ?(standalone = true) ?(wrap_with_fun = `Iife) ~link p =
   |> coloring
   |> check_js
 
-let full
-    (type result)
-    ~(target : result target)
-    ~standalone
-    ~wrap_with_fun
-    ~profile
-    ~link
-    ~source_map
-    d
-    p : result =
+let optimize ~profile p =
+  let deadcode_sentinal =
+    (* If deadcode is disabled, this field is just fresh variable *)
+    Code.Var.fresh_n "dummy"
+  in
   let opt =
     specialize_js_once
     +> (match profile with
        | O1 -> o1
        | O2 -> o2
        | O3 -> o3)
-         ~target:(target_flag target)
     +> exact_calls profile
     +> effects
     +> map_fst
-         ((match target with
-          | JavaScript _ -> Generate_closure.f
-          | Wasm -> Fun.id)
-         +> deadcode')
+         (match Config.target (), Config.Flag.effects () with
+         | `JavaScript, false -> Generate_closure.f
+         | `JavaScript, true | `Wasm, _ -> Fun.id)
+    +> map_fst deadcode'
   in
   if times () then Format.eprintf "Start Optimizing...@.";
   let t = Timer.make () in
-  let r = opt p in
+  let (program, variable_uses), trampolined_calls, in_cps = opt p in
   let () = if times () then Format.eprintf " optimizations : %a@." Timer.print t in
-  match target with
-  | JavaScript formatter ->
-      let exported_runtime = not standalone in
-      let emit formatter =
-        generate d ~exported_runtime ~wrap_with_fun ~warn_on_unhandled_effect:standalone
-        +> link_and_pack ~standalone ~wrap_with_fun ~link
-        +> output formatter ~source_map ()
-      in
-      let source_map = emit formatter r in
-      source_map
-  | Wasm ->
-      let (p, live_vars), _, in_cps = r in
-      live_vars, in_cps, p, d
+  { program; variable_uses; trampolined_calls; in_cps; deadcode_sentinal }
+
+let full ~standalone ~wrap_with_fun ~profile ~link ~source_map ~formatter d p =
+  let optimized_code = optimize ~profile p in
+  let exported_runtime = not standalone in
+  let emit formatter =
+    generate d ~exported_runtime ~wrap_with_fun ~warn_on_unhandled_effect:standalone
+    +> link_and_pack ~standalone ~wrap_with_fun ~link
+    +> output formatter ~source_map ()
+  in
+  emit formatter optimized_code
 
 let full_no_source_map ~formatter ~standalone ~wrap_with_fun ~profile ~link d p =
   let (_ : Source_map.t option) =
-    full
-      ~target:(JavaScript formatter)
-      ~standalone
-      ~wrap_with_fun
-      ~profile
-      ~link
-      ~source_map:None
-      d
-      p
+    full ~standalone ~wrap_with_fun ~profile ~link ~source_map:None ~formatter d p
   in
   ()
 
 let f
-    ~target
     ?(standalone = true)
     ?(wrap_with_fun = `Iife)
     ?(profile = O1)
     ~link
     ?source_map
+    ~formatter
     d
     p =
-  full ~target ~standalone ~wrap_with_fun ~profile ~link ~source_map d p
+  full ~standalone ~wrap_with_fun ~profile ~link ~source_map ~formatter d p
 
 let f' ?(standalone = true) ?(wrap_with_fun = `Iife) ?(profile = O1) ~link formatter d p =
   full_no_source_map ~formatter ~standalone ~wrap_with_fun ~profile ~link d p

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -658,7 +658,7 @@ let link_and_pack ?(standalone = true) ?(wrap_with_fun = `Iife) ?(link = `No) p 
   |> coloring
   |> check_js
 
-let optimize ?(profile = O1) p =
+let optimize ~profile p =
   let deadcode_sentinal =
     (* If deadcode is disabled, this field is just fresh variable *)
     Code.Var.fresh_n "dummy"

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -79,8 +79,7 @@ let specialize' (p, info) =
 
 let specialize p = fst (specialize' p)
 
-let eval (p, info) =
-  if Config.Flag.staticeval () then Eval.f info p else p
+let eval (p, info) = if Config.Flag.staticeval () then Eval.f info p else p
 
 let flow p =
   if debug () then Format.eprintf "Data flow...@.";
@@ -180,10 +179,7 @@ let round1 : 'a -> 'a =
 
 let round2 = flow +> specialize' +> eval +> deadcode +> o1
 
-let o3 =
-  loop 10 "tailcall+inline" round1 1
-  +> loop 10 "flow" round2 1
-  +> print
+let o3 = loop 10 "tailcall+inline" round1 1 +> loop 10 "flow" round2 1 +> print
 
 let generate
     d
@@ -662,7 +658,7 @@ let link_and_pack ?(standalone = true) ?(wrap_with_fun = `Iife) ?(link = `No) p 
   |> coloring
   |> check_js
 
-let optimize ~profile p =
+let optimize ?(profile = O1) p =
   let deadcode_sentinal =
     (* If deadcode is disabled, this field is just fresh variable *)
     Code.Var.fresh_n "dummy"

--- a/compiler/lib/driver.mli
+++ b/compiler/lib/driver.mli
@@ -20,22 +20,26 @@
 
 type profile
 
-type 'a target =
-  | JavaScript : Pretty_print.t -> Source_map.t option target
-  | Wasm
-      : (Deadcode.variable_uses * Effects.in_cps * Code.program * Parse_bytecode.Debug.t)
-        target
+type optimized_result =
+  { program : Code.program
+  ; variable_uses : Deadcode.variable_uses
+  ; trampolined_calls : Effects.trampolined_calls
+  ; in_cps : Effects.in_cps
+  ; deadcode_sentinal : Code.Var.t
+  }
+
+val optimize : profile:profile -> Code.program -> optimized_result
 
 val f :
-     target:'result target
-  -> ?standalone:bool
+     ?standalone:bool
   -> ?wrap_with_fun:[ `Iife | `Anonymous | `Named of string ]
   -> ?profile:profile
   -> link:[ `All | `All_from of string list | `Needed | `No ]
   -> ?source_map:Source_map.t
+  -> formatter:Pretty_print.t
   -> Parse_bytecode.Debug.t
   -> Code.program
-  -> 'result
+  -> Source_map.t option
 
 val f' :
      ?standalone:bool
@@ -57,7 +61,7 @@ val from_string :
 val link_and_pack :
      ?standalone:bool
   -> ?wrap_with_fun:[ `Iife | `Anonymous | `Named of string ]
-  -> link:[ `All | `All_from of string list | `Needed | `No ]
+  -> ?link:[ `All | `All_from of string list | `Needed | `No ]
   -> Javascript.statement_list
   -> Javascript.statement_list
 

--- a/compiler/lib/driver.mli
+++ b/compiler/lib/driver.mli
@@ -28,7 +28,7 @@ type optimized_result =
   ; deadcode_sentinal : Code.Var.t
   }
 
-val optimize : profile:profile -> Code.program -> optimized_result
+val optimize : ?profile:profile -> Code.program -> optimized_result
 
 val f :
      ?standalone:bool

--- a/compiler/lib/driver.mli
+++ b/compiler/lib/driver.mli
@@ -28,7 +28,7 @@ type optimized_result =
   ; deadcode_sentinal : Code.Var.t
   }
 
-val optimize : ?profile:profile -> Code.program -> optimized_result
+val optimize : profile:profile -> Code.program -> optimized_result
 
 val f :
      ?standalone:bool

--- a/compiler/lib/eval.mli
+++ b/compiler/lib/eval.mli
@@ -21,4 +21,4 @@ val clear_static_env : unit -> unit
 
 val set_static_env : string -> string -> unit
 
-val f : target:[ `JavaScript | `Wasm ] -> Flow.info -> Code.program -> Code.program
+val f : Flow.info -> Code.program -> Code.program

--- a/compiler/lib/flow.ml
+++ b/compiler/lib/flow.ml
@@ -331,23 +331,26 @@ let constant_identical ~(target : [ `JavaScript | `Wasm ]) a b =
   | Float a, Float b, `JavaScript -> Float.bitwise_equal a b
   | Float _, Float _, `Wasm -> false
   | NativeString a, NativeString b, `JavaScript -> Native_string.equal a b
+  | NativeString _, NativeString _, `Wasm ->
+      false
+      (* Native strings are boxed (JavaScript objects) in Wasm and are
+          possibly different objects *)
   | String a, String b, `JavaScript -> Config.Flag.use_js_string () && String.equal a b
-  | Int _, Float _, _ | Float _, Int _, _ -> false
+  | String _, String _, `Wasm ->
+      false (* Strings are boxed in Wasm and are possibly different objects *)
+  | Int32 _, Int32 _, `Wasm ->
+      false (* [Int32]s are boxed in Wasm and are possibly different objects *)
+  | Int32 _, Int32 _, `JavaScript -> assert false
+  | NativeInt _, NativeInt _, `Wasm ->
+      false (* [NativeInt]s are boxed in Wasm and are possibly different objects *)
+  | NativeInt _, NativeInt _, `JavaScript -> assert false
   (* All other values may be distinct objects and thus different by [caml_js_equals]. *)
-  | String _, _, _
-  | _, String _, _
-  | NativeString _, _, _
-  | _, NativeString _, _
-  | Float_array _, _, _
-  | _, Float_array _, _
-  | Int64 _, _, _
-  | _, Int64 _, _
-  | Int32 _, _, _
-  | _, Int32 _, _
-  | NativeInt _, _, _
-  | _, NativeInt _, _
-  | Tuple _, _, _
-  | _, Tuple _, _ -> false
+  | Int64 _, Int64 _, _ -> false
+  | Tuple _, Tuple _, _ -> false
+  | Float_array _, Float_array _, _ -> false
+  | (Int _ | Float _ | Int64 _ | Int32 _ | NativeInt _), _, _ -> false
+  | (String _ | NativeString _), _, _ -> false
+  | (Float_array _ | Tuple _), _, _ -> false
 
 let the_const_of ~target info x =
   match x with

--- a/compiler/lib/inline.ml
+++ b/compiler/lib/inline.ml
@@ -264,9 +264,9 @@ let inline ~first_class_primitives live_vars closures pc (outer, blocks, free_pc
 
 let times = Debug.find "times"
 
-let f ~target p live_vars =
+let f p live_vars =
   let first_class_primitives =
-    match target with
+    match Config.target () with
     | `JavaScript -> not (Config.Flag.effects ())
     | `Wasm -> false
   in

--- a/compiler/lib/inline.mli
+++ b/compiler/lib/inline.mli
@@ -18,5 +18,4 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-val f :
-  target:[ `JavaScript | `Wasm ] -> Code.program -> Deadcode.variable_uses -> Code.program
+val f : Code.program -> Deadcode.variable_uses -> Code.program

--- a/compiler/lib/link_js.ml
+++ b/compiler/lib/link_js.ml
@@ -469,7 +469,7 @@ let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~source
               let s = sourceMappingURL_base64 ^ Base64.encode_exn data in
               Line_writer.write oc s
           | Some file ->
-              Source_map.to_file sm ~file;
+              Source_map.to_file sm file;
               let s = sourceMappingURL ^ Filename.basename file in
               Line_writer.write oc s));
       if times () then Format.eprintf "  sourcemap: %a@." Timer.print t

--- a/compiler/lib/link_js.ml
+++ b/compiler/lib/link_js.ml
@@ -412,13 +412,7 @@ let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~source
             List.fold_left units ~init:StringSet.empty ~f:(fun acc (u : Unit_info.t) ->
                 StringSet.union acc (StringSet.of_list u.primitives))
           in
-          let code =
-            Parse_bytecode.link_info
-              ~target:`JavaScript
-              ~symtable:!sym
-              ~primitives
-              ~crcs:[]
-          in
+          let code = Parse_bytecode.link_info ~symtable:!sym ~primitives ~crcs:[] in
           let b = Buffer.create 100 in
           let fmt = Pretty_print.to_buffer b in
           Driver.configure fmt;

--- a/compiler/lib/linker.ml
+++ b/compiler/lib/linker.ml
@@ -186,7 +186,14 @@ module Fragment = struct
     List.fold_left
       ~f:(fun m (k, v) -> StringMap.add k v m)
       ~init:StringMap.empty
-      [ "js-string", Config.Flag.use_js_string; "effects", Config.Flag.effects ]
+      [ "js-string", Config.Flag.use_js_string
+      ; "effects", Config.Flag.effects
+      ; ( "wasm"
+        , fun () ->
+            match Config.target () with
+            | `JavaScript -> false
+            | `Wasm -> true )
+      ]
 
   type t =
     | Always_include of Javascript.program pack

--- a/compiler/lib/linker.ml
+++ b/compiler/lib/linker.ml
@@ -434,7 +434,7 @@ let list_all ?from () =
     provided
     StringSet.empty
 
-let load_fragment ~ignore_always_annotation ~target_env ~filename (f : Fragment.t) =
+let load_fragment ~target_env ~filename (f : Fragment.t) =
   match f with
   | Always_include code ->
       always_included :=
@@ -472,11 +472,9 @@ let load_fragment ~ignore_always_annotation ~target_env ~filename (f : Fragment.
                 filename;
             if always
             then (
-              if not ignore_always_annotation
-              then
-                always_included :=
-                  { ar_filename = filename; ar_program = code; ar_requires = requires }
-                  :: !always_included;
+              always_included :=
+                { ar_filename = filename; ar_program = code; ar_requires = requires }
+                :: !always_included;
               `Ok)
             else
               error
@@ -578,24 +576,19 @@ let check_deps () =
           ())
     code_pieces
 
-let load_file ~ignore_always_annotation ~target_env filename =
+let load_file ~target_env filename =
   List.iter (Fragment.parse_file filename) ~f:(fun frag ->
-      let (`Ok | `Ignored) =
-        load_fragment ~ignore_always_annotation ~target_env ~filename frag
-      in
+      let (`Ok | `Ignored) = load_fragment ~target_env ~filename frag in
       ())
 
-let load_fragments ?(ignore_always_annotation = false) ~target_env ~filename l =
+let load_fragments ~target_env ~filename l =
   List.iter l ~f:(fun frag ->
-      let (`Ok | `Ignored) =
-        load_fragment ~ignore_always_annotation ~target_env ~filename frag
-      in
+      let (`Ok | `Ignored) = load_fragment ~target_env ~filename frag in
       ());
   check_deps ()
 
-let load_files ?(ignore_always_annotation = false) ~target_env l =
-  List.iter l ~f:(fun filename ->
-      load_file ~ignore_always_annotation ~target_env filename);
+let load_files ~target_env l =
+  List.iter l ~f:(fun filename -> load_file ~target_env filename);
   check_deps ()
 
 (* resolve *)

--- a/compiler/lib/linker.mli
+++ b/compiler/lib/linker.mli
@@ -36,15 +36,9 @@ end
 
 val reset : unit -> unit
 
-val load_files :
-  ?ignore_always_annotation:bool -> target_env:Target_env.t -> string list -> unit
+val load_files : target_env:Target_env.t -> string list -> unit
 
-val load_fragments :
-     ?ignore_always_annotation:bool
-  -> target_env:Target_env.t
-  -> filename:string
-  -> Fragment.t list
-  -> unit
+val load_fragments : target_env:Target_env.t -> filename:string -> Fragment.t list -> unit
 
 val check_deps : unit -> unit
 

--- a/compiler/lib/ocaml_compiler.ml
+++ b/compiler/lib/ocaml_compiler.ml
@@ -18,27 +18,28 @@
 
 open! Stdlib
 
-let rec constant_of_const ~target c : Code.constant =
+let rec constant_of_const c : Code.constant =
   let open Lambda in
   let open Asttypes in
   match c with
   | Const_base (Const_int i) ->
       Int
-        (match target with
+        (match Config.target () with
         | `JavaScript -> Int32.of_int_warning_on_overflow i
-        | `Wasm -> Int31.of_int_warning_on_overflow i)
+        | `Wasm -> Int31.(of_int_warning_on_overflow i |> to_int32))
   | Const_base (Const_char c) -> Int (Int32.of_int (Char.code c))
   | ((Const_base (Const_string (s, _))) [@if ocaml_version < (4, 11, 0)])
   | ((Const_base (Const_string (s, _, _))) [@if ocaml_version >= (4, 11, 0)]) -> String s
   | Const_base (Const_float s) -> Float (float_of_string s)
   | Const_base (Const_int32 i) -> (
-      match target with
+      match Config.target () with
       | `JavaScript -> Int i
       | `Wasm -> Int32 i)
   | Const_base (Const_int64 i) -> Int64 i
   | Const_base (Const_nativeint i) -> (
-      match target with
-      | `JavaScript -> Int (Int32.of_nativeint_warning_on_overflow i)
+      let i = Int32.of_nativeint_warning_on_overflow i in
+      match Config.target () with
+      | `JavaScript -> Int i
       | `Wasm -> NativeInt i)
   | Const_immstring s -> String s
   | Const_float_array sl ->
@@ -46,11 +47,11 @@ let rec constant_of_const ~target c : Code.constant =
       Float_array (Array.of_list l)
   | ((Const_pointer i) [@if ocaml_version < (4, 12, 0)]) ->
       Int
-        (match target with
+        (match Config.target () with
         | `JavaScript -> Int32.of_int_warning_on_overflow i
-        | `Wasm -> Int31.of_int_warning_on_overflow i)
+        | `Wasm -> Int31.(of_int_warning_on_overflow i |> to_int32))
   | Const_block (tag, l) ->
-      let l = Array.of_list (List.map l ~f:(fun c -> constant_of_const ~target c)) in
+      let l = Array.of_list (List.map l ~f:(fun c -> constant_of_const c)) in
       Tuple (tag, l, Unknown)
 
 let rec find_loc_in_summary ident' = function

--- a/compiler/lib/ocaml_compiler.mli
+++ b/compiler/lib/ocaml_compiler.mli
@@ -16,8 +16,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-val constant_of_const :
-  target:[ `JavaScript | `Wasm ] -> Lambda.structured_constant -> Code.constant
+val constant_of_const : Lambda.structured_constant -> Code.constant
 
 val find_loc_in_summary : Ident.t -> Env.summary -> Location.t option
 

--- a/compiler/lib/parse_bytecode.mli
+++ b/compiler/lib/parse_bytecode.mli
@@ -52,8 +52,7 @@ end
 val read_primitives : Toc.t -> in_channel -> string list
 
 val from_exe :
-     target:[ `JavaScript | `Wasm ]
-  -> ?includes:string list
+     ?includes:string list
   -> linkall:bool
   -> link_info:bool
   -> include_cmis:bool
@@ -91,8 +90,7 @@ val from_string :
 val predefined_exceptions : unit -> Code.program * Unit_info.t
 
 val link_info :
-     target:[ `JavaScript | `Wasm ]
-  -> symtable:Ocaml_compiler.Symtable.GlobalMap.t
+     symtable:Ocaml_compiler.Symtable.GlobalMap.t
   -> primitives:StringSet.t
   -> crcs:(string * Digest.t option) list
   -> Code.program

--- a/compiler/lib/parse_bytecode.mli
+++ b/compiler/lib/parse_bytecode.mli
@@ -63,8 +63,7 @@ val from_exe :
   -> one
 
 val from_cmo :
-     target:[ `JavaScript | `Wasm ]
-  -> ?includes:string list
+     ?includes:string list
   -> ?include_cmis:bool
   -> ?debug:bool
   -> Cmo_format.compilation_unit
@@ -72,8 +71,7 @@ val from_cmo :
   -> one
 
 val from_cma :
-     target:[ `JavaScript | `Wasm ]
-  -> ?includes:string list
+     ?includes:string list
   -> ?include_cmis:bool
   -> ?debug:bool
   -> Cmo_format.library
@@ -90,7 +88,7 @@ val from_string :
   -> string
   -> Code.program * Debug.t
 
-val predefined_exceptions : target:[ `JavaScript | `Wasm ] -> Code.program * Unit_info.t
+val predefined_exceptions : unit -> Code.program * Unit_info.t
 
 val link_info :
      target:[ `JavaScript | `Wasm ]

--- a/compiler/lib/source_map.mli
+++ b/compiler/lib/source_map.mli
@@ -70,11 +70,6 @@ val to_string : t -> string
 
 val of_string : string -> t
 
-val of_file_no_mappings : string -> t * string option
-(** Read source map from a file without parsing the mappings (which can be costly). The
-    [mappings] field is returned empty and the raw string is returned alongside the map.
- *)
+val to_file : t -> string -> unit
 
-val to_file : ?mappings:string -> t -> file:string -> unit
-(** Write to a file. If a string is supplied as [mappings], use it instead of the
-    sourcemap's [mappings]. *)
+val of_file : string -> t

--- a/compiler/lib/specialize_js.ml
+++ b/compiler/lib/specialize_js.ml
@@ -25,6 +25,9 @@ open Flow
 let specialize_instr ~target info i =
   match i, target with
   | Let (x, Prim (Extern "caml_format_int", [ y; z ])), `JavaScript -> (
+      (* We can implement the special case where the format string is "%s" in JavaScript
+         in a concise and efficient way with [""+x]. It does not make as much sense in
+         Wasm to have a special case for this. *)
       match the_string_of ~target info y with
       | Some "%d" -> (
           match the_int ~target info z with
@@ -41,13 +44,11 @@ let specialize_instr ~target info i =
         , Prim
             ( Extern (("caml_js_var" | "caml_js_expr" | "caml_pure_js_expr") as prim)
             , [ (Pv _ as y) ] ) )
-    , _ )
-    when Config.Flag.safe_string () -> (
+    , target ) -> (
       match the_string_of ~target info y with
       | Some s -> Let (x, Prim (Extern prim, [ Pc (String s) ]))
       | _ -> i)
-  | Let (x, Prim (Extern ("caml_register_named_value" as prim), [ y; z ])), `JavaScript
-    -> (
+  | Let (x, Prim (Extern ("caml_register_named_value" as prim), [ y; z ])), _ -> (
       match the_string_of ~target info y with
       | Some s when Primitive.need_named_value s ->
           Let (x, Prim (Extern prim, [ Pc (String s); z ]))
@@ -134,6 +135,9 @@ let specialize_instr ~target info i =
       | Some s -> Let (x, Constant (NativeString (Native_string.of_bytestring s)))
       | None -> i)
   | Let (x, Prim (Extern "%int_mul", [ y; z ])), `JavaScript -> (
+      (* Using * to multiply integers in JavaScript yields a float; and if the
+         float is large enough, some bits can be lost. So, in the general case,
+         we have to use Math.imul. There is no such issue in Wasm. *)
       match the_int ~target info y, the_int ~target info z with
       | Some j, _ when Int32.(abs j < 0x200000l) ->
           Let (x, Prim (Extern "%direct_int_mul", [ y; z ]))
@@ -262,7 +266,7 @@ let specialize_all_instrs ~target info p =
 
 (****)
 
-let f ~target info p = specialize_all_instrs ~target info p
+let f info p = specialize_all_instrs ~target:(Config.target ()) info p
 
 let f_once p =
   let rec loop acc l =

--- a/compiler/lib/specialize_js.mli
+++ b/compiler/lib/specialize_js.mli
@@ -18,6 +18,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-val f : target:[ `JavaScript | `Wasm ] -> Flow.info -> Code.program -> Code.program
+val f : Flow.info -> Code.program -> Code.program
 
 val f_once : Code.program -> Code.program

--- a/compiler/lib/stdlib.ml
+++ b/compiler/lib/stdlib.ml
@@ -341,7 +341,49 @@ module Int32 = struct
       n
 end
 
-module Int31 = struct
+module type Arith_ops = sig
+  type t
+
+  val neg : t -> t
+
+  val add : t -> t -> t
+
+  val sub : t -> t -> t
+
+  val mul : t -> t -> t
+
+  val div : t -> t -> t
+
+  val rem : t -> t -> t
+
+  val logand : t -> t -> t
+
+  val logor : t -> t -> t
+
+  val logxor : t -> t -> t
+
+  val shift_left : t -> int -> t
+
+  val shift_right : t -> int -> t
+
+  val shift_right_logical : t -> int -> t
+end
+
+module Int31 : sig
+  type t
+
+  include Arith_ops with type t := t
+
+  val of_int_warning_on_overflow : int -> t
+
+  val of_nativeint_warning_on_overflow : nativeint -> t
+
+  val of_int32_warning_on_overflow : int32 -> t
+
+  val to_int32 : t -> int32
+end = struct
+  type t = int32
+
   let wrap i = Int32.(shift_right (shift_left i 1) 1)
 
   let of_int_warning_on_overflow i =
@@ -361,6 +403,54 @@ module Int31 = struct
       ~to_dec:(Printf.sprintf "%nd")
       ~to_hex:(Printf.sprintf "%nx")
       n
+
+  let of_int32_warning_on_overflow n =
+    Int32.convert_warning_on_overflow
+      ~to_int32:(fun i -> wrap i)
+      ~of_int32:Fun.id
+      ~equal:Int32.equal
+      ~to_dec:(Printf.sprintf "%ld")
+      ~to_hex:(Printf.sprintf "%lx")
+      n
+
+  let two_pow n =
+    assert (0 <= n && n <= 31);
+    Int32.shift_left 1l n
+
+  let min_int = Int32.neg (two_pow 30)
+
+  let neg x = if Int32.equal x min_int then x else Int32.neg x
+
+  let int_binop f x y = wrap (f x y)
+
+  let add = int_binop Int32.add
+
+  let sub = int_binop Int32.sub
+
+  let mul = int_binop Int32.mul
+
+  let div = int_binop Int32.div
+
+  let rem = int_binop Int32.rem
+
+  let logand = int_binop Int32.logand
+
+  let logor = int_binop Int32.logor
+
+  let logxor = int_binop Int32.logxor
+
+  let shift_op f x y =
+    (* Limit the shift offset to [0, 31] *)
+    wrap (f x (y land 0x1f))
+
+  let shift_left = shift_op Int32.shift_left
+
+  let shift_right = shift_op Int32.shift_right
+
+  let shift_right_logical a b =
+    shift_op Int32.shift_right_logical (Int32.logand a 0x7fffffffl) b
+
+  let to_int32 (x : t) : int32 = x
 end
 
 module Option = struct

--- a/compiler/lib/stdlib.ml
+++ b/compiler/lib/stdlib.ml
@@ -380,11 +380,15 @@ module Int31 : sig
 
   val of_int32_warning_on_overflow : int32 -> t
 
+  val of_int32_truncate : int32 -> t
+
   val to_int32 : t -> int32
 end = struct
   type t = int32
 
   let wrap i = Int32.(shift_right (shift_left i 1) 1)
+
+  let of_int32_truncate i = wrap i
 
   let of_int_warning_on_overflow i =
     Int32.convert_warning_on_overflow

--- a/compiler/lib/wasm/wa_code_generation.ml
+++ b/compiler/lib/wasm/wa_code_generation.ml
@@ -396,10 +396,12 @@ module Arith = struct
     | W.I31Get (S, n') -> return n'
     | _ -> return (W.RefI31 n)
 
+  let wrap31 n = Int31.(of_int32_truncate n |> to_int32)
+
   let of_int31 n =
     let* n = n in
     match n with
-    | W.RefI31 (Const (I32 n)) -> return (W.Const (I32 (Int31.wrap n)))
+    | W.RefI31 (Const (I32 n)) -> return (W.Const (I32 (wrap31 n)))
     | _ -> return (W.I31Get (S, n))
 end
 
@@ -422,7 +424,7 @@ let bin_op_is_smi (op : W.int_bin_op) =
 
 let rec is_smi e =
   match e with
-  | W.Const (I32 i) -> Int32.equal (Int31.wrap i) i
+  | W.Const (I32 i) -> Int32.equal (Arith.wrap31 i) i
   | UnOp ((I32 op | I64 op), _) -> un_op_is_smi op
   | BinOp ((I32 op | I64 op), _, _) -> bin_op_is_smi op
   | I31Get (S, _) -> true

--- a/compiler/lib/wasm/wa_core_target.ml
+++ b/compiler/lib/wasm/wa_core_target.ml
@@ -411,7 +411,7 @@ module Constant = struct
         let block =
           [ W.DataI32 h
           ; DataI32 0l (*ZZZ DataSym (S "caml_nativeint_ops", 0)*)
-          ; DataI32 (Int32.of_nativeint_warning_on_overflow i)
+          ; DataI32 i
           ]
         in
         context.data_segments <- Code.Var.Map.add name (true, block) context.data_segments;

--- a/compiler/lib/wasm/wa_gc_target.ml
+++ b/compiler/lib/wasm/wa_gc_target.ml
@@ -1035,11 +1035,7 @@ module Constant = struct
         let* e = Memory.make_int32 ~kind:`Int32 (return (W.Const (I32 i))) in
         return (Const, e)
     | NativeInt i ->
-        let* e =
-          Memory.make_int32
-            ~kind:`Nativeint
-            (return (W.Const (I32 (Int32.of_nativeint_warning_on_overflow i))))
-        in
+        let* e = Memory.make_int32 ~kind:`Nativeint (return (W.Const (I32 i))) in
         return (Const, e)
 
   let translate c =

--- a/compiler/lib/wasm/wa_generate.ml
+++ b/compiler/lib/wasm/wa_generate.ml
@@ -161,7 +161,7 @@ module Generate (Target : Wa_target_sig.S) = struct
     | Field (x, n, Float) ->
         Memory.float_array_get
           (load x)
-          (Constant.translate (Int (Int31.of_int_warning_on_overflow n)))
+          (Constant.translate (Int Int31.(of_int_warning_on_overflow n |> to_int32)))
     | Closure _ ->
         Closure.translate
           ~context:ctx.global_context
@@ -676,7 +676,7 @@ module Generate (Target : Wa_target_sig.S) = struct
       | Set_field (x, n, Float, y) ->
           Memory.float_array_set
             (load x)
-            (Constant.translate (Int (Int31.of_int_warning_on_overflow n)))
+            (Constant.translate (Int Int31.(of_int_warning_on_overflow n |> to_int32)))
             (load y)
       | Offset_ref (x, n) ->
           Memory.set_field

--- a/compiler/tests-num/dune
+++ b/compiler/tests-num/dune
@@ -1,11 +1,21 @@
 (executable
  (name main)
+ (modules main test_nats test test_big_ints test_ratios test_nums test_io)
  (libraries num)
  (modes
   js
   (best exe))
  (flags
   (:standard -linkall -w -3-7-33-35-37 -safe-string -no-strict-sequence)))
+
+(library
+ (name test_int31)
+ (modules test_int31)
+ (inline_tests)
+ (enabled_if %{lib-available:qcheck})
+ (preprocess
+  (pps ppx_expect))
+ (libraries js_of_ocaml-compiler qcheck))
 
 (rule
  (target main.referencejs)

--- a/compiler/tests-num/test_int31.ml
+++ b/compiler/tests-num/test_int31.ml
@@ -1,0 +1,194 @@
+open! Js_of_ocaml_compiler.Stdlib
+open QCheck2
+
+let () = Printexc.record_backtrace false
+
+let min_int31 = Int32.(neg (shift_left 1l 30))
+let max_int31 = Int32.(sub (shift_left 1l 30) 1l)
+
+let in_range i =
+  Int32.(min_int31 <= i && i <= max_int31)
+
+let in_range_i32 =
+  Gen.(Int32.of_int <$> int_range (- (1 lsl 30)) (1 lsl 30 - 1))
+
+let out_of_range_int =
+  let open Gen in
+  oneof [ int_range (- (1 lsl 31)) (- (1 lsl 30) - 1);
+          int_range (1 lsl 30) (1 lsl 31 - 1) ]
+
+let out_of_range_i32 =
+  out_of_range_int |> Gen.map Int32.of_int
+
+let t_corner =
+  let open Gen in
+  graft_corners in_range_i32 [min_int31; max_int31] ()
+  |> map Int31.of_int32_warning_on_overflow
+
+let print_t t =
+  Format.sprintf "%ld" (Int31.to_int32 t)
+
+let%expect_test _ =
+  Test.check_exn @@ Test.make ~count:1000 ~name:"Int31.of_int32_warning_on_overflow: normal"
+    in_range_i32
+    (fun i ->
+      Int32.equal Int31.(to_int32 (of_int32_warning_on_overflow i)) i);
+  [%expect ""]
+
+let%expect_test _ =
+  Test.check_exn @@ Test.make ~count:1000 ~name:"Int31.of_int_warning_on_overflow: normal"
+    (Gen.map Int32.to_int in_range_i32)
+    (fun i ->
+      Int.equal (Int31.(to_int32 (of_int_warning_on_overflow i)) |> Int32.to_int) i);
+  [%expect ""]
+
+let%expect_test _ =
+  Test.check_exn @@ Test.make ~count:1000 ~name:"Int31.of_nativeint_warning_on_overflow: normal"
+    (Gen.map Nativeint.of_int32 in_range_i32)
+    (fun i ->
+      Nativeint.equal
+        (Int31.(to_int32 (of_nativeint_warning_on_overflow i)) |> Nativeint.of_int32)
+        i);
+  [%expect ""]
+
+let%expect_test _ =
+  let i = Gen.(generate1 (no_shrink out_of_range_i32)) in
+  let i_trunc = Int32.(shift_right (shift_left i 1) 1) in
+  ignore (Int31.of_int32_warning_on_overflow i);
+  let output = [%expect.output] in
+  let expected =
+    Format.sprintf "Warning: integer overflow: integer 0x%lx (%ld) truncated to 0x%lx (%ld); the generated code might be incorrect.@." i i i_trunc i_trunc
+  in
+  if not (String.equal output expected) then
+    Format.printf "Unexpected output string@.%s@.Expected:@.%s@." output expected;
+  [%expect ""]
+
+let%expect_test _ =
+  let i = Gen.(generate1 (no_shrink out_of_range_int)) in
+  let i_trunc = Int32.(shift_right (shift_left (of_int i) 1) 1) in
+  ignore (Int31.of_int_warning_on_overflow i);
+  let output = [%expect.output] in
+  let expected =
+    Format.sprintf "Warning: integer overflow: integer 0x%x (%d) truncated to 0x%lx (%ld); the generated code might be incorrect.@." i i i_trunc i_trunc
+  in
+  if not (String.equal output expected) then
+    Format.printf "Unexpected output string@.%s@.Expected:@.%s@." output expected;
+  [%expect ""]
+
+let%expect_test _ =
+  let i = Gen.(generate1 (no_shrink (Nativeint.of_int <$> out_of_range_int))) in
+  let i_trunc = Int32.(shift_right (shift_left (Nativeint.to_int32 i) 1) 1) in
+  ignore (Int31.of_nativeint_warning_on_overflow i);
+  let output = [%expect.output] in
+  let expected =
+    Format.sprintf "Warning: integer overflow: integer 0x%nx (%nd) truncated to 0x%lx (%ld); the generated code might be incorrect.@." i i i_trunc i_trunc
+  in
+  if not (String.equal output expected) then
+    Format.printf "Unexpected output string@.%s@.Expected:@.%s@." output expected;
+  [%expect ""]
+
+let modulus = Int32.(shift_left 1l 31)
+
+let canonicalize x =
+  if in_range x then x else Int32.(sub x modulus)
+
+let canon_equal x y =
+  Int32.(=) (canonicalize x) (canonicalize y)
+
+let%expect_test _ =
+  Test.check_exn @@ Test.make ~count:1000 ~name:"Int31.neg"
+    t_corner
+    ~print:print_t
+    (fun i ->
+      let r_int31 = Int31.(neg i |> to_int32) in
+      let r_int32 = Int32.neg (Int31.to_int32 i) in
+      in_range r_int31 && canon_equal r_int31 r_int32);
+  [%expect ""]
+
+let binop_prop op_i31 op_i32 i j =
+  let r_int31 = op_i31 i j |> Int31.to_int32 in
+  let r_int32 = op_i32 (Int31.to_int32 i) (Int31.to_int32 j) in
+  in_range r_int31 && canon_equal r_int31 r_int32
+
+let binop_check ~count ~name op_i31 op_i32 =
+  Test.check_exn @@ Test.make ~count ~name
+    Gen.(tup2 t_corner t_corner)
+    ~print:(Print.tup2 print_t print_t)
+    (fun (i, j) -> binop_prop op_i31 op_i32 i j)
+
+let%expect_test _ =
+  binop_check ~count:1000 ~name:"Int31.add" Int31.add Int32.add;
+  [%expect ""]
+
+let%expect_test _ =
+  binop_check ~count:1000 ~name:"Int31.sub" Int31.sub Int32.sub;
+  [%expect ""]
+
+let%expect_test _ =
+  binop_check ~count:1000 ~name:"Int31.mul" Int31.mul Int32.mul;
+  [%expect ""]
+
+let%expect_test _ =
+  Test.check_exn @@ Test.make ~count:1000 ~name:"Int31.div"
+    Gen.(tup2 t_corner t_corner)
+    ~print:(Print.tup2 print_t print_t)
+    (fun (i, j) ->
+      try binop_prop Int31.div Int32.div i j
+      with Division_by_zero -> Int32.equal (Int31.to_int32 j) 0l)
+
+let%expect_test _ =
+  Test.check_exn @@ Test.make ~count:1000 ~name:"Int31.rem"
+    Gen.(tup2 t_corner t_corner)
+    ~print:(Print.tup2 print_t print_t)
+    (fun (i, j) ->
+      try binop_prop Int31.rem Int32.rem i j
+      with Division_by_zero -> Int32.equal (Int31.to_int32 j) 0l)
+
+let%expect_test _ =
+  binop_check ~count:1000 ~name:"Int31.logand" Int31.logand Int32.logand;
+  [%expect ""]
+
+let%expect_test _ =
+  binop_check ~count:1000 ~name:"Int31.logor" Int31.logor Int32.logor;
+  [%expect ""]
+
+let%expect_test _ =
+  binop_check ~count:1000 ~name:"Int31.logxor" Int31.logxor Int32.logxor;
+  [%expect ""]
+
+let shift_op_prop op_i31 op_i32 x i =
+  let r_int31 = op_i31 x i |> Int31.to_int32 in
+  let r_int32 = op_i32 (Int31.to_int32 x) i in
+  in_range r_int31 && canon_equal r_int31 r_int32
+
+let%expect_test _ =
+  Test.check_exn @@ Test.make ~count:1000 ~name:"Int31.shift_left"
+    Gen.(tup2 t_corner (int_bound 31))
+    ~print:Print.(tup2 print_t int)
+    (fun (x, i) -> shift_op_prop Int31.shift_left Int32.shift_left x i)
+
+let%expect_test _ =
+  Test.check_exn @@ Test.make ~count:1000 ~name:"Int31.shift_right"
+    Gen.(tup2 t_corner (int_bound 31))
+    ~print:Print.(tup2 print_t int)
+    (fun (x, i) -> shift_op_prop Int31.shift_right Int32.shift_right x i)
+
+(* Logical implication *)
+let (-->) p q = not p || q
+
+let%expect_test _ =
+  Test.check_exn @@ Test.make ~count:10_000 ~name:"Int31.shift_right_logical"
+    Gen.(tup2 t_corner (int_bound 31))
+    ~print:Print.(tup2 print_t int)
+    (fun (x, i) ->
+      let r_int31 = Int31.shift_right_logical x i |> Int31.to_int32 in
+      let x_int32 = Int31.to_int32 x in
+      let r_int32 =
+        if Int_replace_polymorphic_compare.( i = 0 ) then x_int32
+        else Int32.(shift_right_logical (logand 0x7fffffffl x_int32) i)
+      in
+      (* The bits should be unchanged if the shift amount is zero, otherwise they should
+         match the result of shifting the 31 lower bits of the canonical representation *)
+      in_range r_int31 && Int32.equal r_int31 r_int32
+      && (Int.equal i 0 --> Int32.(r_int31 = x_int32)));
+  [%expect ""]

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,7 @@
   (re :with-test)
   (cmdliner (>= 1.1.0))
   (sedlex (>= 2.3))
+  (qcheck :with-test)
   menhir
   menhirLib
   menhirSdk

--- a/dune-workspace.dev
+++ b/dune-workspace.dev
@@ -1,4 +1,4 @@
-(lang dune 3.15)
+(lang dune 3.17)
 
 ;; Install the following opam switches, copy this file as
 ;; dune-workspace and run:

--- a/dune-workspace.dev
+++ b/dune-workspace.dev
@@ -1,4 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.15)
 
 ;; Install the following opam switches, copy this file as
 ;; dune-workspace and run:

--- a/js_of_ocaml-compiler.opam
+++ b/js_of_ocaml-compiler.opam
@@ -20,6 +20,7 @@ depends: [
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
   "sedlex" {>= "2.3"}
+  "qcheck" {with-test}
   "menhir"
   "menhirLib"
   "menhirSdk"

--- a/runtime/sys.js
+++ b/runtime/sys.js
@@ -352,6 +352,7 @@ function caml_sys_is_regular_file(name) {
 }
 //Always
 //Requires: caml_fatal_uncaught_exception
+//If: !wasm
 function caml_setup_uncaught_exception_handler() {
   var process = globalThis.process;
   if(process && process.on) {


### PR DESCRIPTION
This integrates PRs ocsigen/js_of_ocaml#1655 and its small preliminary PR ocsigen/js_of_ocaml#1692. The two subsequent commits make the necessary changes in the code of wasm_of_ocaml.