### PR TITLE
Calculate fetchBase once at toplevel

### DIFF
--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -471,9 +471,9 @@
     const f = path.join(path.dirname(require.main.filename), src);
     return require("node:fs/promises").readFile(f);
   }
+  const fetchBase = globalThis?.document?.currentScript?.src;
   function fetchRelative(src) {
-    const base = globalThis?.document?.currentScript?.src;
-    const url = base ? new URL(src, base) : src;
+    const url = fetchBase ? new URL(src, fetchBase) : src;
     return fetch(url);
   }
   const loadCode = isNode ? loadRelative : fetchRelative;


### PR DESCRIPTION
> It's important to note that this will not reference the <script> element if the code in the script is being called as a callback or event handler; it will only reference the element while it's initially being processed.

https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript

Base was applied to the first wasm file, but not to subsequent files. This is an issue if you're loading a page at /foo/bar/baz and have your wasm hosted at /client.bc.wasm.assets, only appears in separate compilation.