### PR TITLE
Use static Object.hasOwn

### DIFF
--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -157,7 +157,7 @@
     new: (c, args) => new c(...args),
     global_this: globalThis,
     iter_props: (o, f) => {
-      for (var nm in o) if (o.hasOwn(nm)) f(nm);
+      for (var nm in o) if (Object.hasOwn(o, nm)) f(nm);
     },
     array_length: (a) => a.length,
     array_get: (a, i) => a[i],


### PR DESCRIPTION
I think the initial change in 90db9c5d997fe8130f3d1be81051615d4aa6f862 meant to use the static hasOwn but instead is calling on the object itself.