### PR TITLE
Fix bad interaction of deadcode elimination and unboxed float records

### DIFF
--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -146,7 +146,9 @@ let generate_prelude ~out_file =
     | Some p -> p
     | None -> assert false
   in
-  let Driver.{ program; variable_uses; in_cps; _ } = Driver.optimize ~profile code in
+  let Driver.{ program; variable_uses; in_cps; deadcode_sentinal; _ } =
+    Driver.optimize ~profile code
+  in
   let context = Wa_generate.start () in
   let debug = Parse_bytecode.Debug.create ~include_cmis:false false in
   let _ =
@@ -155,6 +157,7 @@ let generate_prelude ~out_file =
       ~unit_name:(Some "prelude")
       ~live_vars:variable_uses
       ~in_cps
+      ~deadcode_sentinal
       ~debug
       program
   in
@@ -305,11 +308,20 @@ let run
       | None, Some p -> p
       | None, None -> assert false
     in
-    let Driver.{ program; variable_uses; in_cps; _ } = Driver.optimize ~profile code in
+    let Driver.{ program; variable_uses; in_cps; deadcode_sentinal; _ } =
+      Driver.optimize ~profile code
+    in
     let context = Wa_generate.start () in
     let debug = one.debug in
     let toplevel_name, generated_js =
-      Wa_generate.f ~context ~unit_name ~live_vars:variable_uses ~in_cps ~debug program
+      Wa_generate.f
+        ~context
+        ~unit_name
+        ~live_vars:variable_uses
+        ~in_cps
+        ~deadcode_sentinal
+        ~debug
+        program
     in
     if standalone then Wa_generate.add_start_function ~context toplevel_name;
     Wa_generate.output ch ~context ~debug;

--- a/compiler/lib/wasm/wa_curry.ml
+++ b/compiler/lib/wasm/wa_curry.ml
@@ -257,7 +257,13 @@ module Make (Target : Wa_target_sig.S) = struct
         (fun ~typ closure ->
           let* l = expression_list load l in
           call ?typ ~cps:true ~arity closure l)
-        (let* args = Memory.allocate ~tag:0 (List.map ~f:(fun x -> `Var x) (List.tl l)) in
+        (let* args =
+           (* We don't need the deadcode sentinal when the tag is 0 *)
+           Memory.allocate
+             ~tag:0
+             ~deadcode_sentinal:(Code.Var.fresh ())
+             (List.map ~f:(fun x -> `Var x) (List.tl l))
+         in
          let* make_iterator =
            register_import ~name:"caml_apply_continuation" (Fun (func_type 0))
          in

--- a/compiler/lib/wasm/wa_generate.mli
+++ b/compiler/lib/wasm/wa_generate.mli
@@ -26,6 +26,7 @@ val f :
   -> Code.program
   -> live_vars:int array
   -> in_cps:Effects.in_cps
+  -> deadcode_sentinal:Code.Var.t
   -> debug:Parse_bytecode.Debug.t
   -> Wa_ast.var * (string list * (string * Javascript.expression) list)
 

--- a/compiler/lib/wasm/wa_target_sig.ml
+++ b/compiler/lib/wasm/wa_target_sig.ml
@@ -21,7 +21,10 @@ module type S = sig
 
   module Memory : sig
     val allocate :
-      tag:int -> [ `Expr of Wa_ast.expression | `Var of Wa_ast.var ] list -> expression
+         tag:int
+      -> deadcode_sentinal:Code.Var.t
+      -> [ `Expr of Wa_ast.expression | `Var of Wa_ast.var ] list
+      -> expression
 
     val load_function_pointer :
          cps:bool

--- a/compiler/tests-wasm_of_ocaml/dune
+++ b/compiler/tests-wasm_of_ocaml/dune
@@ -1,8 +1,8 @@
 (executables
- (names gh38 gh46)
+ (names gh38 gh46 gh107)
  (modes js)
  (js_of_ocaml
-  (flags :standard --disable optcall)))
+  (flags :standard --disable optcall --no-inline)))
 
 (rule
  (target gh38.actual)
@@ -23,3 +23,13 @@
   (with-outputs-to
    %{target}
    (run node %{dep:gh46.bc.js}))))
+
+(rule
+ (target gh107.actual)
+ (enabled_if
+  (= %{profile} wasm))
+ (alias runtest)
+ (action
+  (with-outputs-to
+   %{target}
+   (run node %{dep:gh107.bc.js}))))

--- a/compiler/tests-wasm_of_ocaml/gh107.ml
+++ b/compiler/tests-wasm_of_ocaml/gh107.ml
@@ -1,0 +1,11 @@
+[@@@warning "-69"]
+
+type t =
+  { x : float
+  ; y : float
+  }
+
+let () =
+  let f x = { x; y = 2. } in
+  let x = f 1. in
+  Format.eprintf "%f@." x.y


### PR DESCRIPTION
When one of the fields is not used, we fill it with the float value 0. rather than using the generic placeholder `(ref.i31 (i32.const 0))` , which does not make sense.

Fixes #107.