### PR TITLE
Fix and improve the optimization of JavaScript interoperability primitives

### DIFF
--- a/compiler/lib-wasm/generate.ml
+++ b/compiler/lib-wasm/generate.ml
@@ -1170,7 +1170,7 @@ let init () =
   let l =
     [ "caml_ensure_stack_capacity", "%identity"; "caml_callback", "caml_trampoline" ]
   in
-
+  Primitive.register "caml_make_array" `Mutable None None;
   let l =
     if Config.Flag.effects ()
     then ("caml_alloc_stack", "caml_cps_alloc_stack") :: l

--- a/compiler/lib/flow.ml
+++ b/compiler/lib/flow.ml
@@ -410,6 +410,7 @@ let the_string_of ~target info x =
 let the_native_string_of ~target info x =
   match the_const_of ~target info x with
   | Some (NativeString i) -> Some i
+  | Some (String i) -> Some (Native_string.of_bytestring i)
   | _ -> None
 
 let the_block_contents_of info x =

--- a/compiler/lib/flow.mli
+++ b/compiler/lib/flow.mli
@@ -61,6 +61,8 @@ val the_string_of :
 val the_native_string_of :
   target:[ `JavaScript | `Wasm ] -> Info.t -> Code.prim_arg -> Code.Native_string.t option
 
+val the_block_contents_of : Info.t -> Code.prim_arg -> Code.Var.t array option
+
 val the_int :
   target:[ `JavaScript | `Wasm ] -> Info.t -> Code.prim_arg -> Targetint.t option
 

--- a/compiler/lib/specialize_js.ml
+++ b/compiler/lib/specialize_js.ml
@@ -55,22 +55,22 @@ let specialize_instr ~target info i =
       | Some _ -> Let (x, Constant (Int Targetint.zero))
       | None -> i)
   | Let (x, Prim (Extern "caml_js_call", [ f; o; a ])), _ -> (
-      match the_def_of info a with
-      | Some (Block (_, a, _, _)) ->
+      match the_block_contents_of info a with
+      | Some a ->
           let a = Array.map a ~f:(fun x -> Pv x) in
           Let (x, Prim (Extern "%caml_js_opt_call", f :: o :: Array.to_list a))
       | _ -> i)
   | Let (x, Prim (Extern "caml_js_fun_call", [ f; a ])), _ -> (
-      match the_def_of info a with
-      | Some (Block (_, a, _, _)) ->
+      match the_block_contents_of info a with
+      | Some a ->
           let a = Array.map a ~f:(fun x -> Pv x) in
           Let (x, Prim (Extern "%caml_js_opt_fun_call", f :: Array.to_list a))
       | _ -> i)
   | Let (x, Prim (Extern "caml_js_meth_call", [ o; m; a ])), _ -> (
       match the_string_of ~target info m with
       | Some m when Javascript.is_ident m -> (
-          match the_def_of info a with
-          | Some (Block (_, a, _, _)) ->
+          match the_block_contents_of info a with
+          | Some a ->
               let a = Array.map a ~f:(fun x -> Pv x) in
               Let
                 ( x
@@ -79,11 +79,11 @@ let specialize_instr ~target info i =
                     , o
                       :: Pc (NativeString (Native_string.of_string m))
                       :: Array.to_list a ) )
-          | _ -> i)
+          | None -> i)
       | _ -> i)
   | Let (x, Prim (Extern "caml_js_new", [ c; a ])), _ -> (
-      match the_def_of info a with
-      | Some (Block (_, a, _, _)) ->
+      match the_block_contents_of info a with
+      | Some a ->
           let a = Array.map a ~f:(fun x -> Pv x) in
           Let (x, Prim (Extern "%caml_js_opt_new", c :: Array.to_list a))
       | _ -> i)


### PR DESCRIPTION
Some optimizations were no longer applied after the array initialization fix in https://github.com/ocaml-wasm/wasm_of_ocaml/pull/113. The following functions from `Js.Unsafe` were affected: `call`, `fun_call`, `meth_call` and `new_obj`.

The OCaml string is converted to a JavaScript string at compile time. This make us generate better code for the functions `Ojs.{get,set,delete}_prop_ascii` from gen_js_api.