### PR TITLE
Wasm: dispatch lifecycle events when async instantiation completes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 ## Features/Changes
 * Lib: fix the type of some DOM properties and methods (#1747)
 * Test: use dune test stanzas (#1631)
+* Wasm: dispatch `wasmoocaml:loaded` and `wasmoocaml:error` `CustomEvent`s on
+  `globalThis` so that surrounding JavaScript can wait for the asynchronous
+  Wasm instantiation to complete (#11)
 
 # 5.9.1 (02-12-2024) - Lille
 

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -531,35 +531,50 @@
     }
     return { instance: { exports: Object.assign(imports.env, imports.OCaml) } };
   }
-  const wasmModule = await instantiateFromDir();
-
-  var {
-    caml_callback,
-    caml_alloc_tm,
-    caml_start_fiber,
-    caml_handle_uncaught_exception,
-    caml_buffer,
-    caml_extract_string,
-    string_get,
-    string_set,
-    _initialize,
-  } = wasmModule.instance.exports;
-
-  var buffer = caml_buffer?.buffer;
-  var out_buffer = buffer && new Uint8Array(buffer, 0, buffer.length);
-
-  start_fiber = make_promising(caml_start_fiber);
-  var _initialize = make_promising(_initialize);
-  var process = globalThis.process;
-  if (process && process.on) {
-    process.on("uncaughtException", (err, origin) =>
-      caml_handle_uncaught_exception(err),
-    );
-  } else if (globalThis.addEventListener) {
-    globalThis.addEventListener(
-      "error",
-      (event) => event.error && caml_handle_uncaught_exception(event.error),
-    );
+  function dispatchLifecycleEvent(name, detail) {
+    if (
+      typeof globalThis.dispatchEvent === "function" &&
+      typeof CustomEvent === "function"
+    ) {
+      globalThis.dispatchEvent(new CustomEvent(name, { detail }));
+    }
   }
-  await _initialize();
+
+  try {
+    const wasmModule = await instantiateFromDir();
+
+    var {
+      caml_callback,
+      caml_alloc_tm,
+      caml_start_fiber,
+      caml_handle_uncaught_exception,
+      caml_buffer,
+      caml_extract_string,
+      string_get,
+      string_set,
+      _initialize,
+    } = wasmModule.instance.exports;
+
+    var buffer = caml_buffer?.buffer;
+    var out_buffer = buffer && new Uint8Array(buffer, 0, buffer.length);
+
+    start_fiber = make_promising(caml_start_fiber);
+    var _initialize = make_promising(_initialize);
+    var process = globalThis.process;
+    if (process && process.on) {
+      process.on("uncaughtException", (err, origin) =>
+        caml_handle_uncaught_exception(err),
+      );
+    } else if (globalThis.addEventListener) {
+      globalThis.addEventListener(
+        "error",
+        (event) => event.error && caml_handle_uncaught_exception(event.error),
+      );
+    }
+    await _initialize();
+    dispatchLifecycleEvent("wasmoocaml:loaded", { src });
+  } catch (error) {
+    dispatchLifecycleEvent("wasmoocaml:error", { src, error });
+    throw error;
+  }
 };


### PR DESCRIPTION
## Summary

- Fixes #11: surrounding JavaScript has no way to know when the asynchronous Wasm instantiation has finished, so user code that runs from `DOMContentLoaded` can race against the OCaml exports being defined.
- The generated launcher invokes the runtime as `init_fun(primitives)(runtime_arguments)` and discards the returned Promise, so callers can't simply await it. Instead, the runtime now dispatches a `wasmoocaml:loaded` `CustomEvent` on `globalThis` after `_initialize()` resolves, and a `wasmoocaml:error` event (with the thrown error in `detail.error`) if anything in the instantiation pipeline rejects.
- Both events carry `detail.src` (the assets directory name passed in `args.src`) so listeners can disambiguate when multiple Wasm modules are loaded on the same page.
- Listener example:
  ```js
  addEventListener("wasmoocaml:loaded", (e) => {
    // OCaml exports are now available; e.detail.src identifies the module.
    synthesize(...);
  });
  ```

## Test plan

- [x] `node --check runtime/wasm/runtime.js` passes (syntax check).
- [x] `npx -p @biomejs/biome@1.9.1 biome check runtime/wasm/runtime.js` passes.
- [ ] Manual verification with the `fiat-html` reproducer from #11: replace the `setTimeout(..., 1)` with a `wasmoocaml:loaded` listener and confirm `synthesize` is defined when the handler fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)